### PR TITLE
8312128: Change JavaFX release version to 21.0.1 in jfx21u

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -24,7 +24,7 @@
 [general]
 project=openjfx
 jbs=jdk
-version=jfx21
+version=jfx21.0.1
 
 [repository]
 tags=(jdk-){0,1}([1-9]([0-9]*)(\.(0|[1-9][0-9]*)){0,3})(\+(([0-9]+))|(-ga))|[1-9]((\.\d{1,3}){0,2})-((b\d{2,3})|(ga))|[1-9]u(\d{1,3})-((b\d{2,3})|(ga))

--- a/build.properties
+++ b/build.properties
@@ -41,7 +41,7 @@ jfx.release.suffix=-ea
 # UPDATE THE FOLLOWING VALUES FOR A NEW RELEASE
 jfx.release.major.version=21
 jfx.release.minor.version=0
-jfx.release.security.version=0
+jfx.release.security.version=1
 jfx.release.patch.version=0
 
 # Note: The release version is now calculated in build.gradle as the


### PR DESCRIPTION
Updates for the beginning of the 21.0.1 release.