### PR TITLE
8313711: Cherry-pick WebKit 616.1 stabilization fixes

### DIFF
--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/CMakeLists.txt
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/CMakeLists.txt
@@ -155,13 +155,24 @@ list(APPEND JavaScriptCore_SOURCES
     ${JavaScriptCore_DERIVED_SOURCES_DIR}/JSCBuiltins.cpp
 )
 
-add_custom_command(
+find_program(TOUCH_EXECUTABLE touch)
+if (TOUCH_EXECUTABLE)
+    add_custom_command(
     OUTPUT ${JavaScriptCore_DERIVED_SOURCES_DIR}/JSCBytecodeCacheVersion.cpp
     MAIN_DEPENDENCY ${JAVASCRIPTCORE_DIR}/runtime/JSCBytecodeCacheVersion.cpp.in
     COMMAND ${PERL_EXECUTABLE} -pe s/CACHED_TYPES_CKSUM/__TIMESTAMP__/ ${JAVASCRIPTCORE_DIR}/runtime/JSCBytecodeCacheVersion.cpp.in > ${JavaScriptCore_DERIVED_SOURCES_DIR}/JSCBytecodeCacheVersion.cpp
+        COMMAND ${TOUCH_EXECUTABLE} -r ${JAVASCRIPTCORE_DIR}/runtime/JSCBytecodeCacheVersion.cpp.in ${JavaScriptCore_DERIVED_SOURCES_DIR}/JSCBytecodeCacheVersion.cpp
             VERBATIM
-)
-
+    )
+else ()
+    message(WARNING "Unable to find touch executable; ${JavaScriptCore_DERIVED_SOURCES_DIR}/JSCBytecodeCacheVersion.cpp is built non-reproducibly from ${JAVASCRIPTCORE_DIR}/runtime/JSCBytecodeCacheVersion.cpp.in")
+    add_custom_command(
+        OUTPUT ${JavaScriptCore_DERIVED_SOURCES_DIR}/JSCBytecodeCacheVersion.cpp
+        MAIN_DEPENDENCY ${JAVASCRIPTCORE_DIR}/runtime/JSCBytecodeCacheVersion.cpp.in
+        COMMAND ${PERL_EXECUTABLE} -pe s/CACHED_TYPES_CKSUM/__TIMESTAMP__/ ${JAVASCRIPTCORE_DIR}/runtime/JSCBytecodeCacheVersion.cpp.in > ${JavaScriptCore_DERIVED_SOURCES_DIR}/JSCBytecodeCacheVersion.cpp
+            VERBATIM
+    )
+endif ()
 
 set(JavaScriptCore_FRAMEWORKS
     WTF

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/b3/B3DuplicateTails.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/b3/B3DuplicateTails.cpp
@@ -77,7 +77,16 @@ public:
             if (block->last()->type() != Void) // Demoting doesn't handle terminals with values.
                 continue;
 
-            candidates.add(block);
+            bool canCopyBlock = true;
+            for (Value* value : *block) {
+                if (value->kind().isCloningForbidden()) {
+                    canCopyBlock = false;
+                    break;
+                }
+            }
+
+            if (canCopyBlock)
+                candidates.add(block);
         }
 
         // Collect the set of values that must be de-SSA'd.

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/b3/B3Kind.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/b3/B3Kind.cpp
@@ -43,6 +43,8 @@ void Kind::dump(PrintStream& out) const
         out.print(comma, "Traps");
     if (isSensitiveToNaN())
         out.print(comma, "SensitiveToNaN");
+    if (isCloningForbidden())
+        out.print(comma, "CloningForbidden");
     if (comma.didPrint())
         out.print(">");
 }

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/b3/B3Kind.h
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/b3/B3Kind.h
@@ -176,6 +176,29 @@ public:
         m_isSensitiveToNaN = isSensitiveToNaN;
     }
 
+    static constexpr bool hasCloningForbidden(Opcode opcode)
+    {
+        switch (opcode) {
+        case Patchpoint:
+            return true;
+        default:
+            return false;
+        }
+    }
+    bool hasCloningForbidden() const
+    {
+        return hasCloningForbidden(m_opcode);
+    }
+    bool isCloningForbidden() const
+    {
+        return m_cloningForbidden;
+    }
+    void setIsCloningForbidden(bool isCloningForbidden)
+    {
+        ASSERT(hasCloningForbidden());
+        m_cloningForbidden = isCloningForbidden;
+    }
+
     // Rules for adding new properties:
     // - Put the accessors here.
     // - hasBlah() should check if the opcode allows for your property.
@@ -189,7 +212,8 @@ public:
         return m_opcode == other.m_opcode
             && m_isChill == other.m_isChill
             && m_traps == other.m_traps
-            && m_isSensitiveToNaN == other.m_isSensitiveToNaN;
+            && m_isSensitiveToNaN == other.m_isSensitiveToNaN
+            && m_cloningForbidden == other.m_cloningForbidden;
     }
 
     bool operator!=(const Kind& other) const
@@ -203,7 +227,7 @@ public:
     {
         // It's almost certainly more important that this hash function is cheap to compute than
         // anything else. We can live with some kind hash collisions.
-        return m_opcode + (static_cast<unsigned>(m_isChill) << 16) + (static_cast<unsigned>(m_traps) << 7) + (static_cast<unsigned>(m_isSensitiveToNaN) << 24);
+        return m_opcode + (static_cast<unsigned>(m_isChill) << 16) + (static_cast<unsigned>(m_traps) << 7) + (static_cast<unsigned>(m_isSensitiveToNaN) << 24) + (static_cast<unsigned>(m_cloningForbidden) << 13);
     }
 
     Kind(WTF::HashTableDeletedValueType)
@@ -222,6 +246,7 @@ private:
     bool m_isChill : 1 { false };
     bool m_traps : 1 { false };
     bool m_isSensitiveToNaN : 1 { false };
+    bool m_cloningForbidden : 1 { false };
 };
 
 // For every flag 'foo' you add, it's customary to create a Kind B3::foo(Kind) function that makes
@@ -247,6 +272,12 @@ inline Kind trapping(Kind kind)
 inline Kind sensitiveToNaN(Kind kind)
 {
     kind.setIsSensitiveToNaN(true);
+    return kind;
+}
+
+inline Kind cloningForbidden(Kind kind)
+{
+    kind.setIsCloningForbidden(true);
     return kind;
 }
 

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/b3/B3PatchpointValue.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/b3/B3PatchpointValue.cpp
@@ -51,10 +51,11 @@ void PatchpointValue::dumpMeta(CommaPrinter& comma, PrintStream& out) const
         out.print(comma, "numFPScratchRegisters = ", numFPScratchRegisters);
 }
 
-PatchpointValue::PatchpointValue(Type type, Origin origin)
-    : Base(CheckedOpcode, Patchpoint, type, origin)
+PatchpointValue::PatchpointValue(Type type, Origin origin, Kind kind)
+    : Base(CheckedOpcode, kind, type, origin)
     , effects(Effects::forCall())
 {
+    ASSERT(accepts(kind));
     if (!type.isTuple())
         resultConstraints.append(type == Void ? ValueRep::WarmAny : ValueRep::SomeRegister);
 }

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/b3/B3PatchpointValue.h
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/b3/B3PatchpointValue.h
@@ -37,7 +37,7 @@ class PatchpointValue final : public StackmapValue {
 public:
     typedef StackmapValue Base;
 
-    static bool accepts(Kind kind) { return kind == Patchpoint; }
+    static bool accepts(Kind kind) { return kind.opcode() == Patchpoint; }
 
     ~PatchpointValue() final;
 
@@ -71,7 +71,8 @@ private:
     friend class Value;
 
     static Opcode opcodeFromConstructor(Type, Origin) { return Patchpoint; }
-    JS_EXPORT_PRIVATE PatchpointValue(Type, Origin);
+    static Opcode opcodeFromConstructor(Type, Origin, Kind) { return Patchpoint; }
+    JS_EXPORT_PRIVATE PatchpointValue(Type, Origin, Kind = Patchpoint);
 };
 
 } } // namespace JSC::B3

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
@@ -100,6 +100,7 @@ public:
         : m_min(min)
         , m_max(max)
     {
+        ASSERT(m_min <= m_max);
     }
 
     template<typename T>
@@ -448,9 +449,15 @@ public:
     {
         ASSERT(m_min >= INT32_MIN);
         ASSERT(m_max <= INT32_MAX);
-        int32_t min = m_min;
-        int32_t max = m_max;
-        return IntRange(static_cast<uint64_t>(static_cast<uint32_t>(min)), static_cast<uint64_t>(static_cast<uint32_t>(max)));
+        uint64_t min = static_cast<uint64_t>(static_cast<uint32_t>(m_min));
+        uint64_t max = static_cast<uint64_t>(static_cast<uint32_t>(m_max));
+        if (m_max < 0 || m_min >= 0) {
+            // m_min = -2, m_max = -1 then should return [0xFFFF_FFFE, 0xFFFF_FFFF]
+            // m_min =  1, m_max =  2 then should return [1, 2]
+            return IntRange(min, max);
+        }
+        // m_min = a negative integer, m_max >= 0 then should return [0, 0xFFFF_FFFF]
+        return IntRange(0, std::numeric_limits<uint32_t>::max());
     }
 
 private:

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/b3/B3ValueInlines.h
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/b3/B3ValueInlines.h
@@ -243,6 +243,7 @@ ALWAYS_INLINE size_t Value::adjacencyListOffset() const
 
 ALWAYS_INLINE Value* Value::cloneImpl() const
 {
+    ASSERT(!kind().isCloningForbidden());
 #define VALUE_TYPE_CLONE(ValueType) allocate<ValueType>(*static_cast<const ValueType*>(this))
     DISPATCH_ON_KIND(VALUE_TYPE_CLONE);
 #undef VALUE_TYPE_CLONE

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/bytecode/ObjectPropertyConditionSet.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/bytecode/ObjectPropertyConditionSet.cpp
@@ -230,13 +230,23 @@ ObjectPropertyCondition generateCondition(
         break;
     }
     case PropertyCondition::Equivalence: {
+        JSValue value;
+        {
+            Locker<JSCellLock> cellLocker { NoLockingNecessary };
+            if (concurrency != Concurrency::MainThread) {
+                cellLocker = Locker { object->cellLock() };
+                if (object->structure() != structure)
+                    return ObjectPropertyCondition();
+                // The structure might change from now on, but we are guaranteed to have a sane view of the butterfly.
+            }
         unsigned attributes;
         PropertyOffset offset = structure->get(vm, concurrency, uid, attributes);
         if (offset == invalidOffset)
             return ObjectPropertyCondition();
-        JSValue value = object->getDirect(concurrency, structure, offset);
+            value = object->getDirect(cellLocker, concurrency, structure, offset);
         if (!value)
             return ObjectPropertyCondition();
+        }
         result = ObjectPropertyCondition::equivalence(vm, owner, object, uid, value);
         break;
     }

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/bytecode/PropertyCondition.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/bytecode/PropertyCondition.cpp
@@ -71,21 +71,6 @@ void PropertyCondition::dump(PrintStream& out) const
     dumpInContext(out, nullptr);
 }
 
-ALWAYS_INLINE static bool nonStructurePropertyMayBecomeReadOnlyWithoutTransition(Structure* structure, UniquedStringImpl* uid)
-{
-    switch (structure->typeInfo().type()) {
-    case ArrayType:
-    case DerivedArrayType:
-        return uid == structure->vm().propertyNames->length.impl();
-
-    case RegExpObjectType:
-        return uid == structure->vm().propertyNames->lastIndex.impl();
-
-    default:
-        return false;
-    }
-}
-
 bool PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint(
     Concurrency concurrency, Structure* structure, JSObject* base) const
 {
@@ -201,9 +186,13 @@ bool PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint(
                 }
                 return false;
             }
-        } else if (nonStructurePropertyMayBecomeReadOnlyWithoutTransition(structure, uid())) {
+        } else if (structure->typeInfo().overridesPut() && JSObject::mightBeSpecialProperty(structure->vm(), structure->typeInfo().type(), uid())) {
             if (PropertyConditionInternal::verbose)
-                dataLog("Invalid because its put() override may treat ", uid(), " property as read-only.\n");
+                dataLog("Invalid because its put() override may treat ", uid(), " property as special non-structure one.\n");
+            return false;
+        } else if (structure->hasNonReifiedStaticProperties() && structure->classInfoForCells()->hasStaticReadOnlyOrGetterSetterProperty(uid())) {
+            if (PropertyConditionInternal::verbose)
+                dataLog("Invalid because we expected not to have a setter, but we have one in non-reified static property table: ", uid(), ".\n");
             return false;
         }
 
@@ -282,6 +271,9 @@ bool PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint(
     }
 
     case Equivalence: {
+        Locker<JSCellLock> cellLocker { NoLockingNecessary };
+        if (concurrency != Concurrency::MainThread && base)
+            cellLocker = Locker { base->cellLock() };
         if (!base || base->structure() != structure) {
             // Conservatively return false, since we cannot verify this one without having the
             // object.
@@ -306,8 +298,8 @@ bool PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint(
             return false;
         }
 
-        JSValue currentValue = base->getDirect(concurrency, structure, currentOffset);
-        if (currentValue != requiredValue()) {
+        JSValue currentValue = base->getDirect(cellLocker, concurrency, structure, currentOffset);
+        if (currentValue != requiredValue() || !currentValue) {
             if (PropertyConditionInternal::verbose) {
                 dataLog(
                     "Invalid because the value is ", currentValue, " but we require ", requiredValue(),
@@ -510,9 +502,13 @@ bool PropertyCondition::isValidValueForPresence(JSValue value) const
 
 PropertyCondition PropertyCondition::attemptToMakeEquivalenceWithoutBarrier(JSObject* base) const
 {
+    JSValue value;
+    {
+        Locker cellLocker { base->cellLock() };
     Structure* structure = base->structure();
 
-    JSValue value = base->getDirectConcurrently(structure, offset());
+        value = base->getDirectConcurrently(cellLocker, structure, offset());
+    }
     if (!isValidValueForPresence(value))
         return PropertyCondition();
     return equivalenceWithoutBarrier(uid(), value);

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -1326,11 +1326,12 @@ JSValue Graph::tryGetConstantProperty(
     // incompatible with the getDirect we're trying to do. The easiest way to do that is to
     // determine if the structure belongs to the proven set.
 
+    Locker cellLock { object->cellLock() };
     Structure* structure = object->structure();
     if (!structureSet.toStructureSet().contains(structure))
         return JSValue();
 
-    return object->getDirectConcurrently(structure, offset);
+    return object->getDirectConcurrently(cellLock, structure, offset);
 }
 
 JSValue Graph::tryGetConstantProperty(JSValue base, Structure* structure, PropertyOffset offset)

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/dfg/DFGPreciseLocalClobberize.h
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/dfg/DFGPreciseLocalClobberize.h
@@ -191,13 +191,19 @@ private:
         case CreateRest: {
             bool isForwardingNode = false;
             bool isPhantomNode = false;
+            bool mayReadArguments = false;
             switch (m_node->op()) {
             case ForwardVarargs:
+            // This is used iff allInlineFramesAreTailCalls, so we will
+            // actually do a real tail call and destroy our frame.
+            case TailCallForwardVarargs:
+                isForwardingNode = true;
+                break;
             case CallForwardVarargs:
             case ConstructForwardVarargs:
-            case TailCallForwardVarargs:
             case TailCallForwardVarargsInlinedCaller:
                 isForwardingNode = true;
+                mayReadArguments = true;
                 break;
             case PhantomDirectArguments:
             case PhantomClonedArguments:
@@ -209,6 +215,9 @@ private:
 
             if (isPhantomNode && m_graph.m_plan.isFTL())
                 break;
+
+            if (mayReadArguments)
+                readWorld(m_node);
 
             if (isForwardingNode && m_node->hasArgumentsChild() && m_node->argumentsChild()
                 && (m_node->argumentsChild()->op() == PhantomNewArrayWithSpread || m_node->argumentsChild()->op() == PhantomSpread)) {

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -8830,7 +8830,7 @@ void SpeculativeJIT::compileGetTypedArrayByteOffset(Node* node)
 #if USE(LARGE_TYPED_ARRAYS)
         load64(Address(baseGPR, JSArrayBufferView::offsetOfByteOffset()), resultGPR);
         // AI promises that the result of GetTypedArrayByteOffset will be Int32, so we must uphold that promise here.
-        speculationCheck(ExitKind::Overflow, JSValueRegs(), nullptr, branch32(Above, resultGPR, TrustedImm32(std::numeric_limits<int32_t>::max())));
+        speculationCheck(ExitKind::Overflow, JSValueRegs(), nullptr, branch64(Above, resultGPR, TrustedImm32(std::numeric_limits<int32_t>::max())));
 #else
         load32(Address(baseGPR, JSArrayBufferView::offsetOfByteOffset()), resultGPR);
 #endif
@@ -8856,7 +8856,7 @@ void SpeculativeJIT::compileGetTypedArrayByteOffset(Node* node)
 #if USE(LARGE_TYPED_ARRAYS)
     load64(Address(baseGPR, JSArrayBufferView::offsetOfByteOffset()), resultGPR);
     // AI promises that the result of GetTypedArrayByteOffset will be Int32, so we must uphold that promise here.
-    speculationCheck(ExitKind::Overflow, JSValueRegs(), nullptr, branch32(Above, resultGPR, TrustedImm32(std::numeric_limits<int32_t>::max())));
+    speculationCheck(ExitKind::Overflow, JSValueRegs(), nullptr, branch64(Above, resultGPR, TrustedImm32(std::numeric_limits<int32_t>::max())));
 #else
     load32(Address(baseGPR, JSArrayBufferView::offsetOfByteOffset()), resultGPR);
 #endif

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/inspector/ScriptCallStack.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/inspector/ScriptCallStack.cpp
@@ -53,7 +53,7 @@ ScriptCallStack::ScriptCallStack(Vector<ScriptCallFrame>&& frames, bool truncate
     , m_truncated(truncated)
     , m_parentStackTrace(parentStackTrace)
 {
-    ASSERT(m_frames.size() < maxCallStackSizeToCapture);
+    ASSERT(m_frames.size() <= maxCallStackSizeToCapture);
 }
 
 ScriptCallStack::~ScriptCallStack()

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.cpp
@@ -248,15 +248,14 @@ void InspectorConsoleAgent::addConsoleMessage(std::unique_ptr<ConsoleMessage> co
         if (m_enabled)
             previousMessage->updateRepeatCountInConsole(*m_frontendDispatcher);
     } else {
-        ConsoleMessage* newMessage = consoleMessage.get();
-        m_consoleMessages.append(WTFMove(consoleMessage));
         if (m_enabled) {
             auto generatePreview = !m_isAddingMessageToFrontend;
             SetForScope isAddingMessageToFrontend(m_isAddingMessageToFrontend, true);
 
-            newMessage->addToFrontend(*m_frontendDispatcher, m_injectedScriptManager, generatePreview);
+            consoleMessage->addToFrontend(*m_frontendDispatcher, m_injectedScriptManager, generatePreview);
         }
 
+        m_consoleMessages.append(WTFMove(consoleMessage));
         if (m_consoleMessages.size() >= maximumConsoleMessages) {
             m_expiredConsoleMessageCount += expireConsoleMessagesStep;
             m_consoleMessages.remove(0, expireConsoleMessagesStep);

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -2384,7 +2384,7 @@ static void handleVarargsCheckpoint(VM& vm, CallFrame* callFrame, JSGlobalObject
     unsigned firstVarArg = bytecode.m_firstVarArg;
 
     MarkedArgumentBuffer args;
-    args.fill(argumentCountIncludingThis - 1, [&] (JSValue* buffer) {
+    args.fill(vm, argumentCountIncludingThis - 1, [&](JSValue* buffer) {
         loadVarargs(globalObject, buffer, callFrame->r(bytecode.m_arguments).jsValue(), firstVarArg, argumentCountIncludingThis - 1);
     });
     if (args.hasOverflowed()) {

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/runtime/ArgList.h
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/runtime/ArgList.h
@@ -205,14 +205,21 @@ public:
     }
 
     template<typename Functor>
-    void fill(size_t count, const Functor& func)
+    void fill(VM& vm, size_t count, const Functor& func)
     {
         ASSERT(!m_size);
         ensureCapacity(count);
         if (OverflowHandler::hasOverflowed())
             return;
+        if (LIKELY(!m_markSet)) {
+            m_markSet = &vm.heap.markListSet();
+            m_markSet->add(this);
+        }
         m_size = count;
-        func(reinterpret_cast<JSValue*>(&slotFor(0)));
+        auto* buffer = reinterpret_cast<JSValue*>(&slotFor(0));
+        for (unsigned i = 0; i < count; ++i)
+            buffer[i] = JSValue();
+        func(buffer);
     }
 
 private:

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/runtime/ClassInfo.h
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/runtime/ClassInfo.h
@@ -209,6 +209,7 @@ struct CLASS_INFO_ALIGNMENT ClassInfo {
     JS_EXPORT_PRIVATE void dump(PrintStream&) const;
 
     JS_EXPORT_PRIVATE bool hasStaticSetterOrReadonlyProperties() const;
+    JS_EXPORT_PRIVATE bool hasStaticReadOnlyOrGetterSetterProperty(UniquedStringImpl*) const;
 };
 
 } // namespace JSC

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/runtime/JSArray.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/runtime/JSArray.cpp
@@ -1033,6 +1033,7 @@ bool JSArray::unshiftCountWithArrayStorage(JSGlobalObject* globalObject, unsigne
         Structure* structure = this->structure();
         ConcurrentJSLocker structureLock(structure->lock());
         Butterfly* newButterfly = storage->butterfly()->unshift(structure, count);
+
         storage = newButterfly->arrayStorage();
         storage->m_indexBias -= count;
         storage->setVectorLength(vectorLength + count);

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/runtime/JSCell.h
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/runtime/JSCell.h
@@ -123,12 +123,12 @@ public:
 
     // Each cell has a built-in lock. Currently it's simply available for use if you need it. It's
     // a full-blown WTF::Lock. Note that this lock is currently used in JSArray and that lock's
-    // ordering with the Structure lock is that the Structure lock must be acquired first.
+    // ordering with the Structure lock is that the cell lock must be acquired first.
 
     // We use this abstraction to make it easier to grep for places where we lock cells.
     // to lock a cell you can just do:
-    // Locker locker { cell->cellLocker() };
-    JSCellLock& cellLock() { return *reinterpret_cast<JSCellLock*>(this); }
+    // Locker locker { cell->cellLock() };
+    JSCellLock& cellLock() const { return *reinterpret_cast<JSCellLock*>(const_cast<JSCell*>(this)); }
 
     JSType type() const;
     IndexingType indexingTypeAndMisc() const;

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
@@ -276,8 +276,12 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncCopyWithin(VM& vm, JS
         // https://tc39.es/proposal-resizablearraybuffer/#sec-%typedarray%.prototype.copywithin
         if (updatedLength.value() != length) {
             length = updatedLength.value();
-            if (std::max(to, from) + count > length)
+            if (std::max(to, from) + count > length) {
+                // Either to or from index is larger than the updated length. In this case, we do not need to copy anything and finish copyWithin.
+                if (std::max(to, from) > length)
+                    return JSValue::encode(callFrame->thisValue());
                 count = length - std::max(to, from);
+        }
         }
 
     typename ViewClass::ElementType* array = thisObject->typedVector();

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/runtime/JSObject.h
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/runtime/JSObject.h
@@ -206,6 +206,7 @@ public:
     static bool putInlineForJSObject(JSCell*, JSGlobalObject*, PropertyName, JSValue, PutPropertySlot&);
 
     JS_EXPORT_PRIVATE static bool put(JSCell*, JSGlobalObject*, PropertyName, JSValue, PutPropertySlot&);
+    static bool mightBeSpecialProperty(VM&, JSType, UniquedStringImpl*);
     JS_EXPORT_PRIVATE NEVER_INLINE static bool definePropertyOnReceiver(JSGlobalObject*, PropertyName, JSValue, PutPropertySlot&);
     // putByIndex assumes that the receiver is this JSCell object.
     JS_EXPORT_PRIVATE static bool putByIndex(JSCell*, JSGlobalObject*, unsigned propertyName, JSValue, bool shouldThrow);
@@ -824,8 +825,8 @@ public:
 
     // Fast access to known property offsets.
     ALWAYS_INLINE JSValue getDirect(PropertyOffset offset) const { return locationForOffset(offset)->get(); }
-    JSValue getDirect(Concurrency, Structure* expectedStructure, PropertyOffset) const;
-    JSValue getDirectConcurrently(Structure* expectedStructure, PropertyOffset) const;
+    JSValue getDirect(Locker<JSCellLock>&, Concurrency, Structure* expectedStructure, PropertyOffset) const;
+    JSValue getDirectConcurrently(Locker<JSCellLock>&, Structure* expectedStructure, PropertyOffset) const;
     void putDirectOffset(VM& vm, PropertyOffset offset, JSValue value) { locationForOffset(offset)->set(vm, this, value); }
     void putDirectWithoutBarrier(PropertyOffset offset, JSValue value) { locationForOffset(offset)->setWithoutWriteBarrier(value); }
 
@@ -1393,22 +1394,25 @@ inline JSValue JSObject::getPrototype(VM&, JSGlobalObject* globalObject)
 // shrink the butterfly when we are holding the Structure's ConcurrentJSLock, such as when we
 // flatten an object.
 IGNORE_RETURN_TYPE_WARNINGS_BEGIN
-ALWAYS_INLINE JSValue JSObject::getDirect(Concurrency concurrency, Structure* expectedStructure, PropertyOffset offset) const
+ALWAYS_INLINE JSValue JSObject::getDirect(Locker<JSCellLock>& cellLock, Concurrency concurrency, Structure* expectedStructure, PropertyOffset offset) const
 {
     switch (concurrency) {
     case Concurrency::MainThread:
         ASSERT(!isCompilationThread() && !Thread::mayBeGCThread());
         return getDirect(offset);
     case Concurrency::ConcurrentThread:
-        return getDirectConcurrently(expectedStructure, offset);
+        return getDirectConcurrently(cellLock, expectedStructure, offset);
     }
 }
 IGNORE_RETURN_TYPE_WARNINGS_END
 
-inline JSValue JSObject::getDirectConcurrently(Structure* structure, PropertyOffset offset) const
+inline JSValue JSObject::getDirectConcurrently(Locker<JSCellLock>&, Structure* expectedStructure, PropertyOffset offset) const
 {
-    ConcurrentJSLocker locker(structure->lock());
-    if (!structure->isValidOffset(offset))
+    // We always take the cell lock before the structure lock.
+    // We must take the cell lock to prevent places like JSArray::unshiftCountWithArrayStorage
+    // from changing the butterfly out from under us.
+    ConcurrentJSLocker locker { expectedStructure->lock() };
+    if (!expectedStructure->isValidOffset(offset))
         return { };
     return getDirect(offset);
 }

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/runtime/PropertySlot.h
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/runtime/PropertySlot.h
@@ -49,6 +49,7 @@ enum class PropertyAttribute : unsigned {
     CustomAccessorOrValue = CustomAccessor | CustomValue,
     AccessorOrCustomAccessorOrValue = Accessor | CustomAccessor | CustomValue,
     ReadOnlyOrAccessorOrCustomAccessor = ReadOnly | Accessor | CustomAccessor,
+    ReadOnlyOrAccessorOrCustomAccessorOrValue = ReadOnly | Accessor | CustomAccessor | CustomValue,
 
     // Things that are used by static hashtables are not in the attributes byte in PropertyTableEntry.
     Function          = 1 << 8,  // property is a function - only used by static hashtables

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -1844,6 +1844,9 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncToWellFormed, (JSGlobalObject* globalObj
     String string = stringValue->value(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
+    if (string.is8Bit())
+        return JSValue::encode(stringValue);
+
     const UChar* characters = string.characters16();
     unsigned length = string.length();
     auto firstIllFormedIndex = illFormedIndex(characters, length);

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/runtime/Structure.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/runtime/Structure.cpp
@@ -1431,6 +1431,19 @@ bool ClassInfo::hasStaticSetterOrReadonlyProperties() const
     return false;
 }
 
+bool ClassInfo::hasStaticReadOnlyOrGetterSetterProperty(UniquedStringImpl* uid) const
+{
+    for (const ClassInfo* ci = this; ci; ci = ci->parentClass) {
+        if (const HashTable* table = ci->staticPropHashTable) {
+            if (!table->hasSetterOrReadonlyProperties)
+                continue;
+            if (const HashTableValue* entry = table->entry(uid))
+                return entry->attributes() & PropertyAttribute::ReadOnlyOrAccessorOrCustomAccessorOrValue;
+        }
+    }
+    return false;
+}
+
 void Structure::setCachedPropertyNameEnumerator(VM& vm, JSPropertyNameEnumerator* enumerator, StructureChain* chain)
 {
     ASSERT(typeInfo().isObject());

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
@@ -3681,7 +3681,7 @@ auto B3IRGenerator::addDelegateToUnreachable(ControlType& target, ControlType& d
 
 auto B3IRGenerator::addThrow(unsigned exceptionIndex, Vector<ExpressionType>& args, Stack&) -> PartialResult
 {
-    PatchpointValue* patch = m_proc.add<PatchpointValue>(B3::Void, origin());
+    PatchpointValue* patch = m_proc.add<PatchpointValue>(B3::Void, origin(), cloningForbidden(Patchpoint));
     patch->effects.terminal = true;
     patch->append(instanceValue(), ValueRep::reg(GPRInfo::argumentGPR0));
     for (unsigned i = 0; i < args.size(); ++i) {
@@ -3706,7 +3706,7 @@ auto B3IRGenerator::addThrow(unsigned exceptionIndex, Vector<ExpressionType>& ar
 
 auto B3IRGenerator::addRethrow(unsigned, ControlType& data) -> PartialResult
 {
-    PatchpointValue* patch = m_proc.add<PatchpointValue>(B3::Void, origin());
+    PatchpointValue* patch = m_proc.add<PatchpointValue>(B3::Void, origin(), cloningForbidden(Patchpoint));
     patch->clobber(RegisterSetBuilder::registersToSaveForJSCall(m_proc.usesSIMD() ? RegisterSetBuilder::allRegisters() : RegisterSetBuilder::allScalarRegisters()));
     patch->effects.terminal = true;
     patch->append(instanceValue(), ValueRep::reg(GPRInfo::argumentGPR0));

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
@@ -1224,7 +1224,7 @@ auto LLIntGenerator::addThrow(unsigned exceptionIndex, Vector<ExpressionType>& a
     // delayed moves, but the wasm_throw opcode expects all the arguments to be contiguous
     // in the stack. The reason we don't call materializeConstantsAndLocals here is that
     // it expects a stack, not a vector of ExpressionType arguments.
-    walkExpressionStack(args, [&](VirtualRegister& arg, VirtualRegister slot) {
+    walkExpressionStack(args, m_stackSize + args.size(), [&](VirtualRegister& arg, VirtualRegister slot) {
         if (arg == slot)
             return;
         WasmMov::emit(this, slot, arg);

--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/URLHelpers.cpp
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/URLHelpers.cpp
@@ -203,8 +203,12 @@ static bool isLookalikeCharacter(const std::optional<UChar32>& previousCodePoint
 
     if (!u_isprint(codePoint)
         || u_isUWhiteSpace(codePoint)
-        || u_hasBinaryProperty(codePoint, UCHAR_DEFAULT_IGNORABLE_CODE_POINT)
-        || ublock_getCode(codePoint) == UBLOCK_IPA_EXTENSIONS)
+        || u_hasBinaryProperty(codePoint, UCHAR_DEFAULT_IGNORABLE_CODE_POINT))
+        return true;
+
+    auto block = ublock_getCode(codePoint);
+    if (block == UBLOCK_IPA_EXTENSIONS
+        || block == UBLOCK_DESERET)
         return true;
 
     switch (codePoint) {
@@ -214,6 +218,10 @@ static bool isLookalikeCharacter(const std::optional<UChar32>& previousCodePoint
     /* 0x0131 LATIN SMALL LETTER DOTLESS I is intentionally not considered a lookalike character because it is visually distinguishable from i and it has legitimate use in the Turkish language. */
     case 0x01C0: /* LATIN LETTER DENTAL CLICK */
     case 0x01C3: /* LATIN LETTER RETROFLEX CLICK */
+    case 0x1E9C: /* LATIN SMALL LETTER LONG S WITH DIAGONAL STROKE */
+    case 0x1E9D: /* LATIN SMALL LETTER LONG S WITH HIGH STROKE */
+    case 0x1EFE: /* LATIN CAPITAL LETTER Y WITH LOOP */
+    case 0x1EFF: /* LATIN SMALL LETTER Y WITH LOOP */
     case 0x0237: /* LATIN SMALL LETTER DOTLESS J */
     case 0x0251: /* LATIN SMALL LETTER ALPHA */
     case 0x0261: /* LATIN SMALL LETTER SCRIPT G */

--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -104,6 +104,7 @@ enum class SDKAlignedBehavior {
     UIBackForwardSkipsHistoryItemsWithoutUserGesture,
     ProgrammaticFocusDuringUserScriptShowsInputViews,
     UsesGameControllerPhysicalInputProfile,
+    EvaluateJavaScriptWithoutTransientActivation,
 
     NumberOfBehaviors
 };

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/indexeddb/IDBRequest.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/indexeddb/IDBRequest.cpp
@@ -296,10 +296,15 @@ void IDBRequest::dispatchEvent(Event& event)
     LOG(IndexedDB, "IDBRequest::dispatchEvent - %s (%p)", event.type().string().utf8().data(), this);
 
     ASSERT(canCurrentThreadAccessThreadLocalData(originThread()));
-    ASSERT(m_hasPendingActivity);
     ASSERT(!isContextStopped());
 
     Ref protectedThis { *this };
+    if (!event.isTrusted()) {
+        EventDispatcher::dispatchEvent({ this }, event);
+        return;
+    }
+
+    ASSERT(m_hasPendingActivity);
     m_eventBeingDispatched = &event;
 
     if (event.type() != eventNames().blockedEvent)
@@ -312,9 +317,7 @@ void IDBRequest::dispatchEvent(Event& event)
     else if (m_transaction && !m_transaction->didDispatchAbortOrCommit())
         targets = { this, m_transaction.get(), &m_transaction->database() };
 
-    if (event.isTrusted())
         m_hasPendingActivity = false;
-
     {
         TransactionActivator activator(m_transaction.get());
         EventDispatcher::dispatchEvent(targets, event);

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/websockets/WebSocket.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/websockets/WebSocket.cpp
@@ -308,7 +308,8 @@ ExceptionOr<void> WebSocket::connect(const String& url, const Vector<String>& pr
         Document& document = downcast<Document>(context);
         RefPtr<Frame> frame = document.frame();
         // FIXME: make the mixed content check equivalent to the non-document mixed content check currently in WorkerThreadableWebSocketChannel::Bridge::connect()
-        if (!frame || !MixedContentChecker::canRunInsecureContent(*frame, document.securityOrigin(), m_url)) {
+        // In particular we need to match the error messaging in the console and the inspector instrumentation. See WebSocketChannel::fail.
+        if (!frame || !MixedContentChecker::frameAndAncestorsCanRunInsecureContent(*frame, document.securityOrigin(), m_url)) {
             failAsynchronously();
             return { };
         }

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/websockets/WorkerThreadableWebSocketChannel.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/websockets/WorkerThreadableWebSocketChannel.cpp
@@ -414,13 +414,10 @@ void WorkerThreadableWebSocketChannel::Bridge::connect(const URL& url, const Str
 
         auto& document = downcast<Document>(context);
 
-        // FIXME: make this mixed content check equivalent to the document mixed content check currently in WebSocket::connect()
-        if (auto* frame = document.frame()) {
-            if (auto errorString = MixedContentChecker::checkForMixedContentInFrameTree(*frame, url)) {
-                peer->fail(WTFMove(errorString).value());
+        if (document.frame() && !MixedContentChecker::frameAndAncestorsCanRunInsecureContent(*document.frame(), document.securityOrigin(), url, MixedContentChecker::ShouldLogWarning::No)) {
+            peer->fail(makeString("The page at ", document.url().stringCenterEllipsizedToLength(), " was blocked from connecting insecurely to ", url.stringCenterEllipsizedToLength(), " either because the protocol is insecure or the page is embedded from an insecure page."));
                 return;
             }
-        }
 
         if (peer->connect(url, protocol) == ThreadableWebSocketChannel::ConnectStatus::KO)
             peer->didReceiveMessageError(String { });

--- a/modules/javafx.web/src/main/native/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1097,8 +1097,7 @@ void KeyframeEffect::computedNeedsForcedLayout()
         if (keyframeStyle->hasTransform()) {
             auto& transformOperations = keyframeStyle->transform();
             for (const auto& operation : transformOperations.operations()) {
-                if (operation->isTranslateTransformOperationType()) {
-                    auto translation = downcast<TranslateTransformOperation>(operation.get());
+                if (auto* translation = dynamicDowncast<TranslateTransformOperation>(operation.get())) {
                     if (translation->x().isPercent() || translation->y().isPercent()) {
                         m_needsForcedLayout = true;
                         return;

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/js/RunJavaScriptParameters.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/js/RunJavaScriptParameters.h
@@ -34,34 +34,38 @@ namespace WebCore {
 
 enum class RunAsAsyncFunction : bool { No, Yes };
 enum class ForceUserGesture : bool { No, Yes };
+enum class RemoveTransientActivation : bool { No, Yes };
 
 using ArgumentWireBytesMap = HashMap<String, Vector<uint8_t>>;
 
 struct RunJavaScriptParameters {
-    RunJavaScriptParameters(String&& source, URL&& sourceURL, RunAsAsyncFunction runAsAsyncFunction, std::optional<ArgumentWireBytesMap>&& arguments, ForceUserGesture forceUserGesture)
+    RunJavaScriptParameters(String&& source, URL&& sourceURL, RunAsAsyncFunction runAsAsyncFunction, std::optional<ArgumentWireBytesMap>&& arguments, ForceUserGesture forceUserGesture, RemoveTransientActivation removeTransientActivation)
         : source(WTFMove(source))
         , sourceURL(WTFMove(sourceURL))
         , runAsAsyncFunction(runAsAsyncFunction)
         , arguments(WTFMove(arguments))
         , forceUserGesture(forceUserGesture)
+        , removeTransientActivation(removeTransientActivation)
     {
     }
 
-    RunJavaScriptParameters(const String& source, URL&& sourceURL, bool runAsAsyncFunction, std::optional<ArgumentWireBytesMap>&& arguments, bool forceUserGesture)
+    RunJavaScriptParameters(const String& source, URL&& sourceURL, bool runAsAsyncFunction, std::optional<ArgumentWireBytesMap>&& arguments, bool forceUserGesture, RemoveTransientActivation removeTransientActivation)
         : source(source)
         , sourceURL(WTFMove(sourceURL))
         , runAsAsyncFunction(runAsAsyncFunction ? RunAsAsyncFunction::Yes : RunAsAsyncFunction::No)
         , arguments(WTFMove(arguments))
         , forceUserGesture(forceUserGesture ? ForceUserGesture::Yes : ForceUserGesture::No)
+        , removeTransientActivation(removeTransientActivation)
     {
     }
 
-    RunJavaScriptParameters(String&& source, URL&& sourceURL, bool runAsAsyncFunction, std::optional<ArgumentWireBytesMap>&& arguments, bool forceUserGesture)
+    RunJavaScriptParameters(String&& source, URL&& sourceURL, bool runAsAsyncFunction, std::optional<ArgumentWireBytesMap>&& arguments, bool forceUserGesture, RemoveTransientActivation removeTransientActivation)
         : source(WTFMove(source))
         , sourceURL(WTFMove(sourceURL))
         , runAsAsyncFunction(runAsAsyncFunction ? RunAsAsyncFunction::Yes : RunAsAsyncFunction::No)
         , arguments(WTFMove(arguments))
         , forceUserGesture(forceUserGesture ? ForceUserGesture::Yes : ForceUserGesture::No)
+        , removeTransientActivation(removeTransientActivation)
     {
     }
 
@@ -70,10 +74,11 @@ struct RunJavaScriptParameters {
     RunAsAsyncFunction runAsAsyncFunction;
     std::optional<ArgumentWireBytesMap> arguments;
     ForceUserGesture forceUserGesture;
+    RemoveTransientActivation removeTransientActivation;
 
     template<typename Encoder> void encode(Encoder& encoder) const
     {
-        encoder << source << sourceURL << runAsAsyncFunction << arguments << forceUserGesture;
+        encoder << source << sourceURL << runAsAsyncFunction << arguments << forceUserGesture << removeTransientActivation;
     }
 
     template<typename Decoder> static std::optional<RunJavaScriptParameters> decode(Decoder& decoder)
@@ -98,7 +103,11 @@ struct RunJavaScriptParameters {
         if (!decoder.decode(forceUserGesture))
             return std::nullopt;
 
-        return { RunJavaScriptParameters { WTFMove(source), WTFMove(sourceURL), runAsAsyncFunction, WTFMove(arguments), forceUserGesture } };
+        RemoveTransientActivation removeTransientActivation;
+        if (!decoder.decode(removeTransientActivation))
+            return std::nullopt;
+
+        return { RunJavaScriptParameters { WTFMove(source), WTFMove(sourceURL), runAsAsyncFunction, WTFMove(arguments), forceUserGesture, removeTransientActivation } };
     }
 };
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -7412,8 +7412,10 @@ sub GenerateHashTableValueArray
         } elsif ("@$specials[$i]" =~ m/ConstantInteger/) {
             $typeTag = "Constant";
             $hasSecondValue = 0;
+            $hasSetter = "true";
         } elsif ("@$specials[$i]" =~ m/DOMJITAttribute/) {
             $typeTag = "DOMJITAttribute";
+            $hasSetter = "true";
         } else {
             $typeTag = "GetterSetter";
             $hasSetter = "true";

--- a/modules/javafx.web/src/main/native/Source/WebCore/dom/Document.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/dom/Document.cpp
@@ -3874,9 +3874,11 @@ bool Document::isNavigationBlockedByThirdPartyIFrameRedirectBlocking(Frame& targ
     if (m_frame->hasHadUserInteraction())
         return false;
 
-    // Only prevent navigations by unsandboxed iframes. Such navigations by unsandboxed iframes would have already been blocked unless
+    // Only prevent navigations by unsandboxed iframes. Such navigations by sandboxed iframes would have already been blocked unless
     // "allow-top-navigation" / "allow-top-navigation-by-user-activation" was explicitly specified.
-    if (sandboxFlags() != SandboxNone) {
+    // We also want to guard against bypassing this block via an iframe-provided CSP sandbox.
+    auto* ownerElement = m_frame->ownerElement();
+    if ((!ownerElement || ownerElement->sandboxFlags() == sandboxFlags()) && sandboxFlags() != SandboxNone) {
         // Navigation is only allowed if the parent of the sandboxed iframe is first-party.
         RefPtr parentFrame = dynamicDowncast<LocalFrame>(m_frame->tree().parent());
         RefPtr parentDocument = parentFrame ? parentFrame->document() : nullptr;
@@ -3891,10 +3893,13 @@ bool Document::isNavigationBlockedByThirdPartyIFrameRedirectBlocking(Frame& targ
 
     // Only prevent cross-site navigations.
     RefPtr targetDocument = targetFrame.document();
-    if (targetDocument && (targetDocument->securityOrigin().isSameOriginDomain(SecurityOrigin::create(destinationURL)) || areRegistrableDomainsEqual(targetDocument->url(), destinationURL)))
-        return false;
+    if (!targetDocument)
+        return true;
 
+    if (targetDocument->securityOrigin().protocol() != destinationURL.protocol())
     return true;
+
+    return !(targetDocument->securityOrigin().isSameOriginDomain(SecurityOrigin::create(destinationURL)) || areRegistrableDomainsEqual(targetDocument->url(), destinationURL));
 }
 
 void Document::didRemoveAllPendingStylesheet()

--- a/modules/javafx.web/src/main/native/Source/WebCore/dom/Document.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/dom/Document.h
@@ -1752,6 +1752,8 @@ public:
 
     virtual void didChangeViewSize() { }
 
+    bool isNavigationBlockedByThirdPartyIFrameRedirectBlocking(Frame& targetFrame, const URL& destinationURL);
+
 protected:
     enum ConstructionFlags { Synthesized = 1, NonRenderedPlaceholder = 1 << 1 };
     WEBCORE_EXPORT Document(Frame*, const Settings&, const URL&, DocumentClasses = { }, unsigned constructionFlags = 0, ScriptExecutionContextIdentifier = { });
@@ -1854,7 +1856,6 @@ private:
     void didLoadResourceSynchronously(const URL&) final;
 
     bool canNavigateInternal(Frame& targetFrame);
-    bool isNavigationBlockedByThirdPartyIFrameRedirectBlocking(Frame& targetFrame, const URL& destinationURL);
 
 #if USE(QUICK_LOOK)
     bool shouldEnforceQuickLookSandbox() const;

--- a/modules/javafx.web/src/main/native/Source/WebCore/dom/UserGestureIndicator.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/dom/UserGestureIndicator.cpp
@@ -100,6 +100,11 @@ bool UserGestureToken::isValidForDocument(const Document& document) const
     return m_documentsImpactedByUserGesture.contains(document);
 }
 
+void UserGestureToken::forEachImpactedDocument(Function<void(Document&)>&& function)
+{
+    m_documentsImpactedByUserGesture.forEach(function);
+}
+
 UserGestureIndicator::UserGestureIndicator(std::optional<ProcessingUserGestureState> state, Document* document, UserGestureType gestureType, ProcessInteractionStyle processInteractionStyle)
     : m_previousToken { currentToken() }
 {

--- a/modules/javafx.web/src/main/native/Source/WebCore/dom/UserGestureIndicator.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/dom/UserGestureIndicator.h
@@ -105,6 +105,8 @@ public:
 
     bool isValidForDocument(const Document&) const;
 
+    void forEachImpactedDocument(Function<void(Document&)>&&);
+
 private:
     UserGestureToken(ProcessingUserGestureState, UserGestureType, Document*);
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/editing/markup.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/editing/markup.cpp
@@ -192,6 +192,7 @@ std::unique_ptr<Page> createPageForSanitizingWebContent()
     page->settings().setHTMLParserScriptingFlagPolicy(HTMLParserScriptingFlagPolicy::Enabled);
     page->settings().setPluginsEnabled(false);
     page->settings().setAcceleratedCompositingEnabled(false);
+    page->settings().setLinkPreloadEnabled(false);
 
     Frame& frame = page->mainFrame();
     frame.setView(FrameView::create(frame, IntSize { 800, 600 }));

--- a/modules/javafx.web/src/main/native/Source/WebCore/html/CanvasBase.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/html/CanvasBase.h
@@ -60,6 +60,8 @@ public:
 
     virtual void refCanvasBase() = 0;
     virtual void derefCanvasBase() = 0;
+    void ref() { refCanvasBase(); }
+    void deref() { derefCanvasBase(); }
 
     virtual bool isHTMLCanvasElement() const { return false; }
     virtual bool isOffscreenCanvas() const { return false; }

--- a/modules/javafx.web/src/main/native/Source/WebCore/html/HTMLCanvasElement.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/html/HTMLCanvasElement.h
@@ -142,6 +142,9 @@ public:
 #endif
     WEBCORE_EXPORT void setAvoidIOSurfaceSizeCheckInWebProcessForTesting();
 
+    using HTMLElement::ref;
+    using HTMLElement::deref;
+
 private:
     HTMLCanvasElement(const QualifiedName&, Document&);
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/html/HTMLFormElement.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/html/HTMLFormElement.cpp
@@ -509,7 +509,7 @@ void HTMLFormElement::parseAttribute(const QualifiedName& name, const AtomString
         if (!m_attributes.action().isEmpty()) {
             if (RefPtr<Frame> f = document().frame()) {
                 if (auto* topFrame = dynamicDowncast<LocalFrame>(f->tree().top()))
-                    MixedContentChecker::checkFormForMixedContent(*topFrame, topFrame->document()->securityOrigin(), document().completeURL(m_attributes.action()));
+                    MixedContentChecker::checkFormForMixedContent(*topFrame, document().completeURL(m_attributes.action()));
             }
         }
     } else if (name == targetAttr)

--- a/modules/javafx.web/src/main/native/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/html/OffscreenCanvas.cpp
@@ -111,9 +111,9 @@ Ref<OffscreenCanvas> OffscreenCanvas::create(ScriptExecutionContext& scriptExecu
         clone->setOriginTainted();
 
     callOnMainThread([detachedCanvas = WTFMove(detachedCanvas), placeholderData = Ref { *clone->m_placeholderData }] () mutable {
-        placeholderData->canvas = detachedCanvas->takePlaceholderCanvas();
-        if (placeholderData->canvas) {
-            auto& placeholderContext = downcast<PlaceholderRenderingContext>(*placeholderData->canvas->renderingContext());
+        if (RefPtr canvas = detachedCanvas->takePlaceholderCanvas().get()) {
+            placeholderData->canvas = canvas;
+            auto& placeholderContext = downcast<PlaceholderRenderingContext>(*canvas->renderingContext());
             auto& imageBufferPipe = placeholderContext.imageBufferPipe();
             if (imageBufferPipe)
                 placeholderData->bufferPipeSource = imageBufferPipe->source();
@@ -471,6 +471,7 @@ void OffscreenCanvas::setPlaceholderCanvas(HTMLCanvasElement& canvas)
 {
     ASSERT(!m_context);
     ASSERT(isMainThread());
+    Ref protectedCanvas { canvas };
     m_placeholderData->canvas = canvas;
     auto& placeholderContext = downcast<PlaceholderRenderingContext>(*canvas.renderingContext());
     auto& imageBufferPipe = placeholderContext.imageBufferPipe();
@@ -482,10 +483,12 @@ void OffscreenCanvas::pushBufferToPlaceholder()
 {
     callOnMainThread([placeholderData = Ref { *m_placeholderData }] () mutable {
         Locker locker { placeholderData->bufferLock };
-        if (placeholderData->canvas && placeholderData->canvas->document().page() && placeholderData->pendingCommitBuffer) {
-            GraphicsClient& client = placeholderData->canvas->document().page()->chrome();
+        if (RefPtr canvas = placeholderData->canvas.get()) {
+            if (canvas->document().page() && placeholderData->pendingCommitBuffer) {
+                GraphicsClient& client = canvas->document().page()->chrome();
             auto imageBuffer = client.sinkIntoImageBuffer(WTFMove(placeholderData->pendingCommitBuffer));
-            placeholderData->canvas->setImageBufferAndMarkDirty(WTFMove(imageBuffer));
+                canvas->setImageBufferAndMarkDirty(WTFMove(imageBuffer));
+            }
         }
         placeholderData->pendingCommitBuffer = nullptr;
     });

--- a/modules/javafx.web/src/main/native/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -1677,6 +1677,7 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(CanvasBase& sourceCanv
     if (!state().hasInvertibleTransform)
         return { };
 
+    Ref protectedCanvas { sourceCanvas };
     // FIXME: Do this through platform-independent GraphicsContext API.
     ImageBuffer* buffer = sourceCanvas.buffer();
     if (!buffer)

--- a/modules/javafx.web/src/main/native/Source/WebCore/loader/ApplicationManifestLoader.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/loader/ApplicationManifestLoader.cpp
@@ -67,6 +67,8 @@ bool ApplicationManifestLoader::startLoading()
 #endif
 
     auto credentials = m_useCredentials ? FetchOptions::Credentials::Include : FetchOptions::Credentials::Omit;
+    // The "linked resource fetch setup steps" are defined as part of:
+    // https://html.spec.whatwg.org/#link-type-manifest
     auto options = ResourceLoaderOptions(
         SendCallbackPolicy::SendCallbacks,
         ContentSniffingPolicy::SniffContent,
@@ -75,12 +77,13 @@ bool ApplicationManifestLoader::startLoading()
         ClientCredentialPolicy::CannotAskClientForCredentials,
         credentials,
         SecurityCheckPolicy::DoSecurityCheck,
-        FetchOptions::Mode::NoCors,
+        FetchOptions::Mode::Cors,
         CertificateInfoPolicy::DoNotIncludeCertificateInfo,
         ContentSecurityPolicyImposition::DoPolicyCheck,
         DefersLoadingPolicy::AllowDefersLoading,
         CachingPolicy::AllowCaching);
     options.destination = FetchOptions::Destination::Manifest;
+    options.sameOriginDataURLFlag = SameOriginDataURLFlag::Set;
     CachedResourceRequest request(WTFMove(resourceRequest), options);
 
     auto cachedResource = frame->document()->cachedResourceLoader().requestApplicationManifest(WTFMove(request));

--- a/modules/javafx.web/src/main/native/Source/WebCore/loader/DocumentThreadableLoader.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/loader/DocumentThreadableLoader.cpp
@@ -618,7 +618,7 @@ void DocumentThreadableLoader::loadRequest(ResourceRequest&& request, SecurityCh
     ResourceResponse response;
     auto identifier = makeObjectIdentifier<ResourceLoader>(std::numeric_limits<uint64_t>::max());
     if (auto* frame = m_document.frame()) {
-        if (!MixedContentChecker::canRunInsecureContent(*frame, m_document.securityOrigin(), requestURL))
+        if (!MixedContentChecker::frameAndAncestorsCanRunInsecureContent(*frame, m_document.securityOrigin(), requestURL))
             return;
         auto& frameLoader = frame->loader();
         identifier = frameLoader.loadResourceSynchronously(request, m_options.clientCredentialPolicy, m_options, *m_originalHeaders, error, response, data);

--- a/modules/javafx.web/src/main/native/Source/WebCore/loader/FrameLoader.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/loader/FrameLoader.cpp
@@ -3616,6 +3616,13 @@ void FrameLoader::executeJavaScriptURL(const URL& url, const NavigationAction& a
         ownerDocument->incrementLoadEventDelayCount();
 
     bool didReplaceDocument = false;
+    bool requesterSandboxedFromScripts = action.requester() ? (action.requester()->sandboxFlags & SandboxScripts) : false;
+    if (requesterSandboxedFromScripts) {
+        // FIXME: This message should be moved off the console once a solution to https://bugs.webkit.org/show_bug.cgi?id=103274 exists.
+        // This message is identical to the message in ScriptController::canExecuteScripts.
+        if (auto* document = m_frame.document())
+            document->addConsoleMessage(MessageSource::Security, MessageLevel::Error, "Blocked script execution in '" + action.requester()->url.stringCenterEllipsizedToLength() + "' because the document's frame is sandboxed and the 'allow-scripts' permission is not set.");
+    } else
     m_frame.script().executeJavaScriptURL(url, action.requester() ? action.requester()->securityOrigin.ptr() : nullptr, action.shouldReplaceDocumentIfJavaScriptURL(), didReplaceDocument);
 
     // We need to communicate that a load happened, even if the JavaScript URL execution didn't end up replacing the document.

--- a/modules/javafx.web/src/main/native/Source/WebCore/loader/MixedContentChecker.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/loader/MixedContentChecker.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012 Google Inc. All rights reserved.
- * Copyright (C) 2013-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,25 +33,41 @@
 #include "ContentSecurityPolicy.h"
 #include "Document.h"
 #include "Frame.h"
-#include "FrameDestructionObserverInlines.h"
-#include "FrameLoader.h"
-#include "FrameLoaderClient.h"
 #include "SecurityOrigin.h"
-#include "Settings.h"
-#include <wtf/text/CString.h>
-#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
-// static
-bool MixedContentChecker::isMixedContent(SecurityOrigin& securityOrigin, const URL& url)
+static bool isMixedContent(const Document& document, const URL& url)
 {
-    if (securityOrigin.protocol() != "https"_s)
-        return false; // We only care about HTTPS security origins.
-
-    // We're in a secure context, so |url| is mixed content if it's insecure.
+    // sandboxed iframes have an opaque origin so we should perform the mixed content check considering the origin
+    // the iframe would have had if it were not sandboxed.
+    if (document.securityOrigin().protocol() == "https"_s || (document.securityOrigin().isOpaque() && document.url().protocolIs("https"_s)))
     return !SecurityOrigin::isSecure(url);
+
+    return false;
 }
+
+static bool foundMixedContentInFrameTree(const Frame& frame, const URL& url)
+{
+    auto* document = frame.document();
+
+    while (document) {
+        if (isMixedContent(*document, url))
+            return true;
+
+        auto* frame = document->frame();
+        if (!frame || frame->isMainFrame())
+            break;
+
+        auto* abstractParentFrame = frame->tree().parent();
+        RELEASE_ASSERT_WITH_MESSAGE(abstractParentFrame, "Should never have a parentless non main frame");
+        if (auto* parentFrame = dynamicDowncast<Frame>(abstractParentFrame))
+            document = parentFrame->document();
+    }
+
+    return false;
+}
+
 
 static void logWarning(const Frame& frame, bool allowed, ASCIILiteral action, const URL& target)
 {
@@ -60,19 +76,15 @@ static void logWarning(const Frame& frame, bool allowed, ASCIILiteral action, co
     frame.document()->addConsoleMessage(MessageSource::Security, MessageLevel::Warning, message);
 }
 
-bool MixedContentChecker::canDisplayInsecureContent(Frame& frame, SecurityOrigin& securityOrigin, ContentType type, const URL& url, AlwaysDisplayInNonStrictMode alwaysDisplayInNonStrictMode)
+bool MixedContentChecker::frameAndAncestorsCanDisplayInsecureContent(Frame& frame, ContentType type, const URL& url)
 {
-    if (!isMixedContent(securityOrigin, url))
+    if (!foundMixedContentInFrameTree(frame, url))
         return true;
 
     if (!frame.document()->contentSecurityPolicy()->allowRunningOrDisplayingInsecureContent(url))
         return false;
 
-    bool isStrictMode = frame.document()->isStrictMixedContentMode();
-    if (!isStrictMode && alwaysDisplayInNonStrictMode == AlwaysDisplayInNonStrictMode::Yes)
-        return true;
-
-    bool allowed = !isStrictMode && (frame.settings().allowDisplayOfInsecureContent() || type == ContentType::ActiveCanWarn) && !frame.document()->geolocationAccessed();
+    bool allowed = !frame.document()->isStrictMixedContentMode() && (frame.settings().allowDisplayOfInsecureContent() || type == ContentType::ActiveCanWarn) && !frame.document()->geolocationAccessed();
     logWarning(frame, allowed, "display"_s, url);
 
     if (allowed) {
@@ -83,15 +95,16 @@ bool MixedContentChecker::canDisplayInsecureContent(Frame& frame, SecurityOrigin
     return allowed;
 }
 
-bool MixedContentChecker::canRunInsecureContent(Frame& frame, SecurityOrigin& securityOrigin, const URL& url)
+bool MixedContentChecker::frameAndAncestorsCanRunInsecureContent(Frame& frame, SecurityOrigin& securityOrigin, const URL& url, ShouldLogWarning shouldLogWarning)
 {
-    if (!isMixedContent(securityOrigin, url))
+    if (!foundMixedContentInFrameTree(frame, url))
         return true;
 
     if (!frame.document()->contentSecurityPolicy()->allowRunningOrDisplayingInsecureContent(url))
         return false;
 
     bool allowed = !frame.document()->isStrictMixedContentMode() && frame.settings().allowRunningOfInsecureContent() && !frame.document()->geolocationAccessed() && !frame.document()->secureCookiesAccessed();
+    if (LIKELY(shouldLogWarning == ShouldLogWarning::Yes))
     logWarning(frame, allowed, "run"_s, url);
 
     if (allowed) {
@@ -102,43 +115,20 @@ bool MixedContentChecker::canRunInsecureContent(Frame& frame, SecurityOrigin& se
     return allowed;
 }
 
-void MixedContentChecker::checkFormForMixedContent(Frame& frame, SecurityOrigin& securityOrigin, const URL& url)
+void MixedContentChecker::checkFormForMixedContent(Frame& frame, const URL& url)
 {
     // Unconditionally allow javascript: URLs as form actions as some pages do this and it does not introduce
     // a mixed content issue.
     if (url.protocolIsJavaScript())
         return;
 
-    if (!isMixedContent(securityOrigin, url))
+    if (!isMixedContent(*frame.document(), url))
         return;
 
     auto message = makeString("The page at ", frame.document()->url().stringCenterEllipsizedToLength(), " contains a form which targets an insecure URL ", url.stringCenterEllipsizedToLength(), ".\n");
     frame.document()->addConsoleMessage(MessageSource::Security, MessageLevel::Warning, message);
 
     frame.loader().client().didDisplayInsecureContent();
-}
-
-std::optional<String> MixedContentChecker::checkForMixedContentInFrameTree(const Frame& frame, const URL& url)
-{
-    auto* document = frame.document();
-
-    while (document) {
-        RELEASE_ASSERT_WITH_MESSAGE(document->frame(), "An unparented document tried to connect to a websocket with url: %s", url.string().utf8().data());
-
-        auto* frame = document->frame();
-        if (isMixedContent(document->securityOrigin(), url))
-            return makeString("The page at ", document->url().stringCenterEllipsizedToLength(), " was blocked from connecting insecurely to ", url.stringCenterEllipsizedToLength(), " either because the protocol is insecure or the page is embedded from an insecure page.");
-
-        if (frame->isMainFrame())
-            break;
-
-        auto* parentFrame = frame->tree().parent();
-        RELEASE_ASSERT_WITH_MESSAGE(parentFrame, "Should never have a parentless non main frame");
-        if (auto* localParentFrame = dynamicDowncast<LocalFrame>(parentFrame))
-            document = localParentFrame->document();
-    }
-
-    return std::nullopt;
 }
 
 } // namespace WebCore

--- a/modules/javafx.web/src/main/native/Source/WebCore/loader/MixedContentChecker.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/loader/MixedContentChecker.h
@@ -1,64 +1,53 @@
 /*
  * Copyright (C) 2012 Google Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are
- * met:
+ * modification, are permitted provided that the following conditions
+ * are met:
  *
- *     * Redistributions of source code must retain the above copyright
+ * 1.  Redistributions of source code must retain the above copyright
  * notice, this list of conditions and the following disclaimer.
- *     * Redistributions in binary form must reproduce the above
- * copyright notice, this list of conditions and the following disclaimer
- * in the documentation and/or other materials provided with the
- * distribution.
- *     * Neither the name of Google Inc. nor the names of its
- * contributors may be used to endorse or promote products derived from
- * this software without specific prior written permission.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * 3.  Neither the name of Apple Inc. ("Apple") nor the names of
+ *     its contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
- * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
- * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
- * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
- * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #pragma once
 
-#include <optional>
 #include <wtf/Forward.h>
-#include <wtf/Noncopyable.h>
 
 namespace WebCore {
 
 class Frame;
-class FrameLoaderClient;
 class SecurityOrigin;
 
-class MixedContentChecker {
-    WTF_MAKE_NONCOPYABLE(MixedContentChecker);
-public:
-    enum class ContentType {
+namespace MixedContentChecker {
+
+enum class ContentType {
         Active,
         ActiveCanWarn,
-    };
-
-    enum class AlwaysDisplayInNonStrictMode {
-        No,
-        Yes,
-    };
-
-    // FIXME: This should probably have a separate client from FrameLoader.
-    static bool canDisplayInsecureContent(Frame&, SecurityOrigin&, ContentType, const URL&, AlwaysDisplayInNonStrictMode = AlwaysDisplayInNonStrictMode::No);
-    static bool canRunInsecureContent(Frame&, SecurityOrigin&, const URL&);
-    static void checkFormForMixedContent(Frame&, SecurityOrigin&, const URL&);
-    static bool isMixedContent(SecurityOrigin&, const URL&);
-    static std::optional<String> checkForMixedContentInFrameTree(const Frame&, const URL&);
 };
 
+enum class ShouldLogWarning { No, Yes };
+
+bool frameAndAncestorsCanDisplayInsecureContent(Frame&, ContentType, const URL&);
+bool frameAndAncestorsCanRunInsecureContent(Frame&, SecurityOrigin&, const URL&, ShouldLogWarning = ShouldLogWarning::Yes);
+void checkFormForMixedContent(Frame&, const URL&);
+
+} // namespace MixedContentChecker
 } // namespace WebCore

--- a/modules/javafx.web/src/main/native/Source/WebCore/loader/NavigationRequester.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/loader/NavigationRequester.cpp
@@ -54,7 +54,9 @@ NavigationRequester NavigationRequester::from(Document& document)
         document.securityOrigin(),
         document.topOrigin(),
         document.policyContainer(),
-        createGlobalFrameIdentifier(document)
+        document.identifier(),
+        createGlobalFrameIdentifier(document),
+        document.sandboxFlags()
     };
 }
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/loader/NavigationRequester.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/loader/NavigationRequester.h
@@ -27,6 +27,7 @@
 
 #include "GlobalFrameIdentifier.h"
 #include "PolicyContainer.h"
+#include "SecurityContext.h"
 #include "SecurityOrigin.h"
 
 namespace WebCore {
@@ -40,7 +41,10 @@ struct NavigationRequester {
     Ref<SecurityOrigin> securityOrigin;
     Ref<SecurityOrigin> topOrigin;
     PolicyContainer policyContainer;
+    ScriptExecutionContextIdentifier documentIdentifier;
     std::optional<GlobalFrameIdentifier> globalFrameIdentifier;
+    SandboxFlags sandboxFlags;
+
 };
 
 } // namespace WebCore

--- a/modules/javafx.web/src/main/native/Source/WebCore/loader/SubframeLoader.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/loader/SubframeLoader.cpp
@@ -135,7 +135,7 @@ bool FrameLoader::SubframeLoader::pluginIsLoadable(const URL& url)
             return false;
         }
 
-        if (!MixedContentChecker::canRunInsecureContent(m_frame, document->securityOrigin(), url))
+        if (!MixedContentChecker::frameAndAncestorsCanRunInsecureContent(m_frame, document->securityOrigin(), url))
             return false;
     }
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -445,11 +445,7 @@ bool CachedResourceLoader::checkInsecureContent(CachedResource::Type type, const
         // These resource can inject script into the current document (Script,
         // XSL) or exfiltrate the content of the current document (CSS).
         if (Frame* frame = this->frame()) {
-            if (!MixedContentChecker::canRunInsecureContent(*frame, m_document->securityOrigin(), url))
-                return false;
-            auto& top = frame->tree().top();
-            auto* localTop = dynamicDowncast<LocalFrame>(top);
-            if (&top != frame && localTop && !MixedContentChecker::canRunInsecureContent(*localTop, localTop->document()->securityOrigin(), url))
+            if (!MixedContentChecker::frameAndAncestorsCanRunInsecureContent(*frame, m_document->securityOrigin(), url))
                 return false;
         }
         break;
@@ -467,11 +463,7 @@ bool CachedResourceLoader::checkInsecureContent(CachedResource::Type type, const
     case CachedResource::Type::FontResource: {
         // These resources can corrupt only the frame's pixels.
         if (Frame* frame = this->frame()) {
-            if (!MixedContentChecker::canDisplayInsecureContent(*frame, m_document->securityOrigin(), contentTypeFromResourceType(type), url, MixedContentChecker::AlwaysDisplayInNonStrictMode::Yes))
-                return false;
-            auto& topFrame = frame->tree().top();
-            auto* localTopFrame = dynamicDowncast<LocalFrame>(topFrame);
-            if (!localTopFrame || !MixedContentChecker::canDisplayInsecureContent(*localTopFrame, localTopFrame->document()->securityOrigin(), contentTypeFromResourceType(type), url))
+            if (!MixedContentChecker::frameAndAncestorsCanDisplayInsecureContent(*frame, contentTypeFromResourceType(type), url))
                 return false;
         }
         break;

--- a/modules/javafx.web/src/main/native/Source/WebCore/page/DOMWindow.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/page/DOMWindow.cpp
@@ -2647,17 +2647,6 @@ ExceptionOr<RefPtr<Frame>> DOMWindow::createWindow(const String& urlString, cons
 
 ExceptionOr<RefPtr<WindowProxy>> DOMWindow::open(DOMWindow& activeWindow, DOMWindow& firstWindow, const String& urlStringToOpen, const AtomString& frameName, const String& windowFeaturesString)
 {
-#if ENABLE(TRACKING_PREVENTION)
-    if (RefPtr document = this->document()) {
-        if (document->settings().needsSiteSpecificQuirks() && urlStringToOpen == Quirks::BBCRadioPlayerURLString()) {
-            auto radioPlayerDomain = RegistrableDomain(URL { Quirks::staticRadioPlayerURLString() });
-            auto BBCDomain = RegistrableDomain(URL { Quirks::BBCRadioPlayerURLString() });
-            if (!ResourceLoadObserver::shared().hasCrossPageStorageAccess(radioPlayerDomain, BBCDomain))
-                return RefPtr<WindowProxy> { nullptr };
-        }
-    }
-#endif
-
     if (!isCurrentlyDisplayedInFrame())
         return RefPtr<WindowProxy> { nullptr };
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/page/DOMWindow.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/page/DOMWindow.h
@@ -477,7 +477,7 @@ private:
 #endif
 
 #if ENABLE(GAMEPAD)
-    unsigned m_gamepadEventListenerCount { 0 };
+    uint64_t m_gamepadEventListenerCount { 0 };
 #endif
 
     mutable RefPtr<Storage> m_sessionStorage;

--- a/modules/javafx.web/src/main/native/Source/WebCore/page/Quirks.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/page/Quirks.cpp
@@ -1074,33 +1074,6 @@ bool Quirks::hasStorageAccessForAllLoginDomains(const HashSet<RegistrableDomain>
     return true;
 }
 
-const String& Quirks::BBCRadioPlayerURLString()
-{
-    static NeverDestroyed<String> BBCRadioPlayerURLString = "https://www.bbc.co.uk/sounds/player/bbc_world_service"_s;
-    return BBCRadioPlayerURLString;
-}
-
-const String& Quirks::staticRadioPlayerURLString()
-{
-    static NeverDestroyed<String> staticRadioPlayerURLString = "https://static.radioplayer.co.uk/"_s;
-    return staticRadioPlayerURLString;
-}
-
-static bool isBBCDomain(const RegistrableDomain& domain)
-{
-    static NeverDestroyed<RegistrableDomain> BBCDomain = RegistrableDomain(URL { Quirks::BBCRadioPlayerURLString() });
-    return domain == BBCDomain;
-}
-
-static bool isBBCPopUpPlayerElement(const Element& element)
-{
-    auto* parentElement = element.parentElement();
-    if (!element.parentElement() || !element.parentElement()->hasClass() || !parentElement->parentElement() || !parentElement->parentElement()->hasClass())
-        return false;
-
-    return element.parentElement()->classNames().contains("p_audioButton_buttonInner"_s) && parentElement->parentElement()->classNames().contains("hidden"_s);
-}
-
 Quirks::StorageAccessResult Quirks::requestStorageAccessAndHandleClick(CompletionHandler<void(ShouldDispatchClick)>&& completionHandler) const
 {
     auto firstPartyDomain = RegistrableDomain(m_document->topDocument().url());
@@ -1222,32 +1195,6 @@ Quirks::StorageAccessResult Quirks::triggerOptionalStorageAccessQuirk(Element& e
 
                 if (shouldDispatchClick == ShouldDispatchClick::Yes)
                     protectedElement->dispatchMouseEvent(platformEvent, eventType, detail, relatedTarget, IsSyntheticClick::Yes);
-            });
-        }
-
-        static NeverDestroyed<String> BBCRadioPlayerPopUpWindowFeatureString = "featurestring width=400,height=730"_s;
-        static NeverDestroyed<UserScript> BBCUserScript { "function triggerRedirect() { document.location.href = \"https://www.bbc.co.uk/sounds/player/bbc_world_service\"; } window.addEventListener('load', function () { triggerRedirect(); })"_s, URL(aboutBlankURL()), Vector<String>(), Vector<String>(), UserScriptInjectionTime::DocumentEnd, UserContentInjectedFrames::InjectInTopFrameOnly, WaitForNotificationBeforeInjecting::Yes };
-
-        // BBC RadioPlayer case.
-        if (isBBCDomain(domain) && isBBCPopUpPlayerElement(element)) {
-            return requestStorageAccessAndHandleClick([document = m_document] (ShouldDispatchClick shouldDispatchClick) mutable {
-                if (!document || shouldDispatchClick == ShouldDispatchClick::No)
-                    return;
-
-                auto domWindow = document->domWindow();
-                if (domWindow) {
-                    ExceptionOr<RefPtr<WindowProxy>> proxyOrException = domWindow->open(*domWindow, *domWindow, staticRadioPlayerURLString(), emptyAtom(), BBCRadioPlayerPopUpWindowFeatureString);
-                    if (proxyOrException.hasException())
-                        return;
-                    auto proxy = proxyOrException.releaseReturnValue();
-                    auto* abstractFrame = proxy->frame();
-                    if (is<Frame>(abstractFrame)) {
-                        auto* frame = downcast<Frame>(abstractFrame);
-                        auto world = ScriptController::createWorld("bbcRadioPlayerWorld"_s, ScriptController::WorldType::User);
-                        frame->addUserScriptAwaitingNotification(world.get(), BBCUserScript);
-                        return;
-                    }
-                }
             });
         }
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/page/Quirks.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/page/Quirks.h
@@ -143,8 +143,6 @@ public:
 #if ENABLE(TRACKING_PREVENTION)
     static bool isMicrosoftTeamsRedirectURL(const URL&);
     static bool hasStorageAccessForAllLoginDomains(const HashSet<RegistrableDomain>&, const RegistrableDomain&);
-    static const String& BBCRadioPlayerURLString();
-    WEBCORE_EXPORT static const String& staticRadioPlayerURLString();
     StorageAccessResult requestStorageAccessAndHandleClick(CompletionHandler<void(ShouldDispatchClick)>&&) const;
 #endif
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/transforms/IdentityTransformOperation.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/transforms/IdentityTransformOperation.h
@@ -65,4 +65,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_TRANSFORMOPERATION(WebCore::IdentityTransformOperation, type() == WebCore::TransformOperation::Type::Identity)
+SPECIALIZE_TYPE_TRAITS_TRANSFORMOPERATION(WebCore::IdentityTransformOperation, WebCore::TransformOperation::Type::Identity ==)

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/transforms/Matrix3DTransformOperation.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/transforms/Matrix3DTransformOperation.h
@@ -69,4 +69,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_TRANSFORMOPERATION(WebCore::Matrix3DTransformOperation, type() == WebCore::TransformOperation::Type::Matrix3D)
+SPECIALIZE_TYPE_TRAITS_TRANSFORMOPERATION(WebCore::Matrix3DTransformOperation, WebCore::TransformOperation::Type::Matrix3D ==)

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/transforms/MatrixTransformOperation.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/transforms/MatrixTransformOperation.h
@@ -89,4 +89,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_TRANSFORMOPERATION(WebCore::MatrixTransformOperation, type() == WebCore::TransformOperation::Type::Matrix)
+SPECIALIZE_TYPE_TRAITS_TRANSFORMOPERATION(WebCore::MatrixTransformOperation, WebCore::TransformOperation::Type::Matrix ==)

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/transforms/PerspectiveTransformOperation.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/transforms/PerspectiveTransformOperation.h
@@ -84,4 +84,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_TRANSFORMOPERATION(WebCore::PerspectiveTransformOperation, type() == WebCore::TransformOperation::Type::Perspective)
+SPECIALIZE_TYPE_TRAITS_TRANSFORMOPERATION(WebCore::PerspectiveTransformOperation, WebCore::TransformOperation::Type::Perspective ==)

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/transforms/RotateTransformOperation.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/transforms/RotateTransformOperation.cpp
@@ -45,7 +45,7 @@ RotateTransformOperation::RotateTransformOperation(double x, double y, double z,
     , m_z(z)
     , m_angle(angle)
 {
-    ASSERT(isRotateTransformOperationType());
+    RELEASE_ASSERT(isRotateTransformOperationType(type));
 }
 
 bool RotateTransformOperation::operator==(const TransformOperation& other) const

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/transforms/RotateTransformOperation.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/transforms/RotateTransformOperation.h
@@ -85,4 +85,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_TRANSFORMOPERATION(WebCore::RotateTransformOperation, isRotateTransformOperationType())
+SPECIALIZE_TYPE_TRAITS_TRANSFORMOPERATION(WebCore::RotateTransformOperation, WebCore::TransformOperation::isRotateTransformOperationType)

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/transforms/ScaleTransformOperation.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/transforms/ScaleTransformOperation.cpp
@@ -38,7 +38,7 @@ ScaleTransformOperation::ScaleTransformOperation(double sx, double sy, double sz
     , m_y(sy)
     , m_z(sz)
 {
-    ASSERT(isScaleTransformOperationType());
+    RELEASE_ASSERT(isScaleTransformOperationType(type));
 }
 
 bool ScaleTransformOperation::operator==(const TransformOperation& other) const

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/transforms/ScaleTransformOperation.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/transforms/ScaleTransformOperation.h
@@ -80,4 +80,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_TRANSFORMOPERATION(WebCore::ScaleTransformOperation, isScaleTransformOperationType())
+SPECIALIZE_TYPE_TRAITS_TRANSFORMOPERATION(WebCore::ScaleTransformOperation, WebCore::TransformOperation::isScaleTransformOperationType)

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/transforms/SkewTransformOperation.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/transforms/SkewTransformOperation.cpp
@@ -37,7 +37,7 @@ SkewTransformOperation::SkewTransformOperation(double angleX, double angleY, Tra
     , m_angleX(angleX)
     , m_angleY(angleY)
 {
-    ASSERT(isSkewTransformOperationType());
+    RELEASE_ASSERT(isSkewTransformOperationType(type));
 }
 
 bool SkewTransformOperation::operator==(const TransformOperation& other) const

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/transforms/SkewTransformOperation.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/transforms/SkewTransformOperation.h
@@ -68,4 +68,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_TRANSFORMOPERATION(WebCore::SkewTransformOperation, isSkewTransformOperationType())
+SPECIALIZE_TYPE_TRAITS_TRANSFORMOPERATION(WebCore::SkewTransformOperation, WebCore::TransformOperation::isSkewTransformOperationType)

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/transforms/TransformOperation.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/transforms/TransformOperation.h
@@ -107,24 +107,38 @@ public:
 
     virtual bool isRepresentableIn2D() const { return true; }
 
-    bool isRotateTransformOperationType() const
+    static bool isRotateTransformOperationType(Type type)
     {
-        return type() == Type::RotateX || type() == Type::RotateY || type() == Type::RotateZ || type() == Type::Rotate || type() == Type::Rotate3D;
+        return type == Type::RotateX
+            || type == Type::RotateY
+            || type == Type::RotateZ
+            || type == Type::Rotate
+            || type == Type::Rotate3D;
     }
 
-    bool isScaleTransformOperationType() const
+    static bool isScaleTransformOperationType(Type type)
     {
-        return type() == Type::ScaleX || type() == Type::ScaleY || type() == Type::ScaleZ || type() == Type::Scale || type() == Type::Scale3D;
+        return type == Type::ScaleX
+            || type == Type::ScaleY
+            || type == Type::ScaleZ
+            || type == Type::Scale
+            || type == Type::Scale3D;
     }
 
-    bool isSkewTransformOperationType() const
+    static bool isSkewTransformOperationType(Type type)
     {
-        return type() == Type::SkewX || type() == Type::SkewY || type() == Type::Skew;
+        return type == Type::SkewX
+            || type == Type::SkewY
+            || type == Type::Skew;
     }
 
-    bool isTranslateTransformOperationType() const
+    static bool isTranslateTransformOperationType(Type type)
     {
-        return type() == Type::TranslateX || type() == Type::TranslateY || type() == Type::TranslateZ || type() == Type::Translate || type() == Type::Translate3D;
+        return type == Type::TranslateX
+            || type == Type::TranslateY
+            || type == Type::TranslateZ
+            || type == Type::Translate
+            || type == Type::Translate3D;
     }
 
     virtual void dump(WTF::TextStream&) const = 0;
@@ -173,5 +187,5 @@ template<> struct EnumTraits<WebCore::TransformOperation::Type> {
 
 #define SPECIALIZE_TYPE_TRAITS_TRANSFORMOPERATION(ToValueTypeName, predicate) \
 SPECIALIZE_TYPE_TRAITS_BEGIN(ToValueTypeName) \
-    static bool isType(const WebCore::TransformOperation& operation) { return operation.predicate; } \
+    static bool isType(const WebCore::TransformOperation& operation) { return predicate(operation.type()); } \
 SPECIALIZE_TYPE_TRAITS_END()

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/transforms/TranslateTransformOperation.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/transforms/TranslateTransformOperation.cpp
@@ -39,7 +39,7 @@ TranslateTransformOperation::TranslateTransformOperation(const Length& tx, const
     , m_y(ty)
     , m_z(tz)
 {
-    ASSERT(isTranslateTransformOperationType());
+    RELEASE_ASSERT(isTranslateTransformOperationType(type));
 }
 
 bool TranslateTransformOperation::operator==(const TransformOperation& other) const

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/transforms/TranslateTransformOperation.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/transforms/TranslateTransformOperation.h
@@ -89,4 +89,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_TRANSFORMOPERATION(WebCore::TranslateTransformOperation, isTranslateTransformOperationType())
+SPECIALIZE_TYPE_TRAITS_TRANSFORMOPERATION(WebCore::TranslateTransformOperation, WebCore::TransformOperation::isTranslateTransformOperationType)

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/PaintPhase.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/PaintPhase.h
@@ -53,7 +53,7 @@ enum class PaintPhase : uint16_t {
     EventRegion              = 1 << 12,
 };
 
-enum class PaintBehavior : uint16_t {
+enum class PaintBehavior : uint32_t {
     Normal                              = 0,
     SelectionOnly                       = 1 << 0,
     SkipSelectionHighlight              = 1 << 1,
@@ -71,6 +71,7 @@ enum class PaintBehavior : uint16_t {
     AnnotateLinks                       = 1 << 13, // Collect all renderers with links to annotate their URLs (e.g. PDFs)
     EventRegionIncludeForeground        = 1 << 14, // FIXME: Event region painting should use paint phases.
     EventRegionIncludeBackground        = 1 << 15,
+    DontShowVisitedLinks                = 1 << 16,
 };
 
 } // namespace WebCore

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderGrid.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderGrid.cpp
@@ -1817,6 +1817,11 @@ std::optional<LayoutUnit> RenderGrid::inlineBlockBaseline(LineDirectionMode) con
 
 LayoutUnit RenderGrid::columnAxisBaselineOffsetForChild(const RenderBox& child) const
 {
+    // FIXME : CSS Masonry does not properly handle baseline calculations currently.
+    // We will just skip this running this step if we detect the RenderGrid is Masonry for now.
+    if (isMasonry())
+        return LayoutUnit { };
+
     if (isSubgridRows()) {
         RenderGrid* outer = downcast<RenderGrid>(parent());
         if (GridLayoutFunctions::isOrthogonalChild(*outer, *this))
@@ -1828,6 +1833,11 @@ LayoutUnit RenderGrid::columnAxisBaselineOffsetForChild(const RenderBox& child) 
 
 LayoutUnit RenderGrid::rowAxisBaselineOffsetForChild(const RenderBox& child) const
 {
+    // FIXME : CSS Masonry does not properly handle baseline calculations currently.
+    // We will just skip this running this step if we detect the RenderGrid is Masonry for now.
+    if (isMasonry())
+        return LayoutUnit { };
+
     if (isSubgridColumns()) {
         RenderGrid* outer = downcast<RenderGrid>(parent());
         if (GridLayoutFunctions::isOrthogonalChild(*outer, *this))

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderInline.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderInline.cpp
@@ -882,6 +882,11 @@ LayoutSize RenderInline::offsetForInFlowPositionedInline(const RenderBox* child)
         inlinePosition = LayoutUnit::fromFloatRound(firstLineBox()->logicalLeft());
         blockPosition = firstLineBox()->logicalTop();
     } else if (LayoutIntegration::LineLayout::containing(*this)) {
+        if (!layoutBox()) {
+            // Repaint may be issued on subtrees during content mutation with newly inserted renderers.
+            ASSERT(needsLayout());
+            return LayoutSize();
+        }
         if (auto inlineBox = InlineIterator::firstInlineBoxFor(*this)) {
             inlinePosition = LayoutUnit::fromFloatRound(inlineBox->logicalLeftIgnoringInlineDirection());
             blockPosition = inlineBox->logicalTop();

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderLayer.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderLayer.cpp
@@ -3262,6 +3262,9 @@ void RenderLayer::paintLayerContents(GraphicsContext& context, const LayerPainti
         }
         GraphicsContext& currentContext = filterContext ? *filterContext : context;
 
+        if (filterContext)
+            localPaintingInfo.paintBehavior.add(PaintBehavior::DontShowVisitedLinks);
+
         // If this layer's renderer is a child of the subtreePaintRoot, we render unconditionally, which
         // is done by passing a nil subtreePaintRoot down to our renderer (as if no subtreePaintRoot was ever set).
         // Otherwise, our renderer tree may or may not contain the subtreePaintRoot root, so we pass that root along
@@ -3695,6 +3698,9 @@ void RenderLayer::paintForegroundForFragments(const LayerFragments& layerFragmen
 
     if (localPaintingInfo.paintBehavior & PaintBehavior::CompositedOverflowScrollContent)
         localPaintBehavior.add(PaintBehavior::CompositedOverflowScrollContent);
+
+    if (localPaintingInfo.paintBehavior & PaintBehavior::DontShowVisitedLinks)
+        localPaintBehavior.add(PaintBehavior::DontShowVisitedLinks);
 
     GraphicsContextStateSaver stateSaver(context, false);
     EventRegionContextStateSaver eventRegionStateSaver(localPaintingInfo.eventRegionContext);
@@ -5727,6 +5733,7 @@ TextStream& operator<<(TextStream& ts, PaintBehavior behavior)
     case PaintBehavior::AnnotateLinks: ts << "AnnotateLinks"; break;
     case PaintBehavior::EventRegionIncludeForeground: ts << "EventRegionIncludeForeground"; break;
     case PaintBehavior::EventRegionIncludeBackground: ts << "EventRegionIncludeBackground"; break;
+    case PaintBehavior::DontShowVisitedLinks: ts << "DontShowVisitedLinks"; break;
     }
 
     return ts;

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/StyledMarkedText.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/StyledMarkedText.cpp
@@ -53,7 +53,7 @@ static StyledMarkedText resolveStyleForMarkedText(const MarkedText& markedText, 
             style.textStyles.fillColor = renderStyle->computedStrokeColor();
             style.textStyles.strokeColor = renderStyle->computedStrokeColor();
 
-            auto color = TextDecorationPainter::decorationColor(*renderStyle.get());
+            auto color = TextDecorationPainter::decorationColor(*renderStyle.get(), paintInfo.paintBehavior);
             auto decorationStyle = renderStyle->textDecorationStyle();
             auto decorations = renderStyle->textDecorationsInEffect();
 
@@ -113,7 +113,7 @@ static StyledMarkedText resolveStyleForMarkedText(const MarkedText& markedText, 
 StyledMarkedText::Style StyledMarkedText::computeStyleForUnmarkedMarkedText(const RenderText& renderer, const RenderStyle& lineStyle, bool isFirstLine, const PaintInfo& paintInfo)
 {
     StyledMarkedText::Style style;
-    style.textDecorationStyles = TextDecorationPainter::stylesForRenderer(renderer, lineStyle.textDecorationsInEffect(), isFirstLine);
+    style.textDecorationStyles = TextDecorationPainter::stylesForRenderer(renderer, lineStyle.textDecorationsInEffect(), isFirstLine, paintInfo.paintBehavior);
     style.textStyles = computeTextPaintStyle(renderer.frame(), lineStyle, paintInfo);
     style.textShadow = ShadowData::clone(paintInfo.forceTextColor() ? nullptr : lineStyle.textShadow());
     return style;

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/TextDecorationPainter.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/TextDecorationPainter.cpp
@@ -318,13 +318,13 @@ void TextDecorationPainter::paintLineThrough(const ForegroundDecorationGeometry&
         m_context.drawLineForText(rect, m_isPrinting, style == TextDecorationStyle::Double, strokeStyle);
 }
 
-static void collectStylesForRenderer(TextDecorationPainter::Styles& result, const RenderObject& renderer, OptionSet<TextDecorationLine> remainingDecorations, bool firstLineStyle, PseudoId pseudoId)
+static void collectStylesForRenderer(TextDecorationPainter::Styles& result, const RenderObject& renderer, OptionSet<TextDecorationLine> remainingDecorations, bool firstLineStyle, OptionSet<PaintBehavior> paintBehavior, PseudoId pseudoId)
 {
     auto extractDecorations = [&] (const RenderStyle& style, OptionSet<TextDecorationLine> decorations) {
         if (decorations.isEmpty())
             return;
 
-        auto color = TextDecorationPainter::decorationColor(style);
+        auto color = TextDecorationPainter::decorationColor(style, paintBehavior);
         auto decorationStyle = style.textDecorationStyle();
 
         if (decorations.contains(TextDecorationLine::Underline)) {
@@ -375,20 +375,20 @@ static void collectStylesForRenderer(TextDecorationPainter::Styles& result, cons
         extractDecorations(styleForRenderer(*current), remainingDecorations);
 }
 
-Color TextDecorationPainter::decorationColor(const RenderStyle& style)
+Color TextDecorationPainter::decorationColor(const RenderStyle& style, OptionSet<PaintBehavior> paintBehavior)
 {
-    return style.visitedDependentColorWithColorFilter(CSSPropertyTextDecorationColor);
+    return style.visitedDependentColorWithColorFilter(CSSPropertyTextDecorationColor, paintBehavior);
 }
 
-auto TextDecorationPainter::stylesForRenderer(const RenderObject& renderer, OptionSet<TextDecorationLine> requestedDecorations, bool firstLineStyle, PseudoId pseudoId) -> Styles
+auto TextDecorationPainter::stylesForRenderer(const RenderObject& renderer, OptionSet<TextDecorationLine> requestedDecorations, bool firstLineStyle, OptionSet<PaintBehavior> paintBehavior, PseudoId pseudoId) -> Styles
 {
     if (requestedDecorations.isEmpty())
         return { };
 
     Styles result;
-    collectStylesForRenderer(result, renderer, requestedDecorations, false, pseudoId);
+    collectStylesForRenderer(result, renderer, requestedDecorations, false, paintBehavior, pseudoId);
     if (firstLineStyle)
-        collectStylesForRenderer(result, renderer, requestedDecorations, true, pseudoId);
+        collectStylesForRenderer(result, renderer, requestedDecorations, true, paintBehavior, pseudoId);
     result.skipInk = renderer.style().textDecorationSkipInk();
     return result;
 }

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/TextDecorationPainter.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/TextDecorationPainter.h
@@ -78,8 +78,8 @@ public:
     };
     void paintForegroundDecorations(const ForegroundDecorationGeometry&, const Styles&);
 
-    static Color decorationColor(const RenderStyle&);
-    static Styles stylesForRenderer(const RenderObject&, OptionSet<TextDecorationLine> requestedDecorations, bool firstLineStyle = false, PseudoId = PseudoId::None);
+    static Color decorationColor(const RenderStyle&, OptionSet<PaintBehavior> paintBehavior = { });
+    static Styles stylesForRenderer(const RenderObject&, OptionSet<TextDecorationLine> requestedDecorations, bool firstLineStyle = false, OptionSet<PaintBehavior> paintBehavior = { }, PseudoId = PseudoId::None);
     static OptionSet<TextDecorationLine> textDecorationsInEffectForStyle(const TextDecorationPainter::Styles&);
 
 private:

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/TextPaintStyle.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/TextPaintStyle.cpp
@@ -106,7 +106,7 @@ TextPaintStyle computeTextPaintStyle(const Frame& frame, const RenderStyle& line
         }
     }
 
-    paintStyle.fillColor = lineStyle.visitedDependentColorWithColorFilter(CSSPropertyWebkitTextFillColor);
+    paintStyle.fillColor = lineStyle.visitedDependentColorWithColorFilter(CSSPropertyWebkitTextFillColor, paintInfo.paintBehavior);
 
     bool forceBackgroundToWhite = false;
     if (frame.document() && frame.document()->printing()) {

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -2365,10 +2365,13 @@ Color RenderStyle::colorResolvingCurrentColor(const StyleColor& color) const
     return color.resolveColor(this->color());
 }
 
-Color RenderStyle::visitedDependentColor(CSSPropertyID colorProperty) const
+Color RenderStyle::visitedDependentColor(CSSPropertyID colorProperty, OptionSet<PaintBehavior> paintBehavior) const
 {
     Color unvisitedColor = colorResolvingCurrentColor(colorProperty, false);
     if (insideLink() != InsideLink::InsideVisited)
+        return unvisitedColor;
+
+    if (paintBehavior.contains(PaintBehavior::DontShowVisitedLinks))
         return unvisitedColor;
 
 #if ENABLE(CSS_COMPOSITING)
@@ -2390,12 +2393,12 @@ Color RenderStyle::visitedDependentColor(CSSPropertyID colorProperty) const
     return visitedColor.colorWithAlpha(unvisitedColor.alphaAsFloat());
 }
 
-Color RenderStyle::visitedDependentColorWithColorFilter(CSSPropertyID colorProperty) const
+Color RenderStyle::visitedDependentColorWithColorFilter(CSSPropertyID colorProperty, OptionSet<PaintBehavior> paintBehavior) const
 {
     if (!hasAppleColorFilter())
-        return visitedDependentColor(colorProperty);
+        return visitedDependentColor(colorProperty, paintBehavior);
 
-    return colorByApplyingColorFilter(visitedDependentColor(colorProperty));
+    return colorByApplyingColorFilter(visitedDependentColor(colorProperty, paintBehavior));
 }
 
 Color RenderStyle::colorByApplyingColorFilter(const Color& color) const

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/style/RenderStyle.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/style/RenderStyle.h
@@ -138,6 +138,8 @@ class StyleInheritedData;
 class StyleScrollSnapArea;
 class TransformationMatrix;
 
+enum class PaintBehavior : uint32_t;
+
 struct ScrollSnapAlign;
 struct ScrollSnapType;
 
@@ -1660,8 +1662,8 @@ public:
     // Resolves the currentColor keyword (except for the "color" property which has specific semantic).
     WEBCORE_EXPORT Color colorResolvingCurrentColor(const StyleColor&) const;
 
-    WEBCORE_EXPORT Color visitedDependentColor(CSSPropertyID) const;
-    WEBCORE_EXPORT Color visitedDependentColorWithColorFilter(CSSPropertyID) const;
+    WEBCORE_EXPORT Color visitedDependentColor(CSSPropertyID, OptionSet<PaintBehavior> paintBehavior = { }) const;
+    WEBCORE_EXPORT Color visitedDependentColorWithColorFilter(CSSPropertyID, OptionSet<PaintBehavior> paintBehavior = { }) const;
 
     WEBCORE_EXPORT Color colorByApplyingColorFilter(const Color&) const;
     WEBCORE_EXPORT Color colorWithColorFilter(const StyleColor&) const;

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/style/StyleCanvasImage.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/style/StyleCanvasImage.cpp
@@ -77,7 +77,7 @@ RefPtr<Image> StyleCanvasImage::image(const RenderElement* renderer, const Float
         return &Image::nullImage();
 
     ASSERT(clients().contains(const_cast<RenderElement*>(renderer)));
-    auto* element = this->element(renderer->document());
+    RefPtr element = this->element(renderer->document());
     if (!element || !element->buffer())
         return nullptr;
     return element->copiedImage();

--- a/modules/javafx.web/src/main/native/Source/WebCore/style/StyleBuilderConverter.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/style/StyleBuilderConverter.h
@@ -1206,11 +1206,16 @@ inline Vector<GridTrackSize> BuilderConverter::convertGridTrackSizeList(BuilderS
         return trackSizes;
     }
 
-    auto& valueList = downcast<CSSValueList>(value);
     Vector<GridTrackSize> trackSizes;
+    if (is<CSSValueList>(value))  {
+        auto& valueList = downcast<CSSValueList>(value);
     trackSizes.reserveInitialCapacity(valueList.length());
     for (auto& currentValue : valueList)
         validateValueAndAppend(trackSizes, currentValue);
+    } else {
+        trackSizes.reserveInitialCapacity(1);
+        validateValueAndAppend(trackSizes, value);
+    }
     return trackSizes;
 }
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/workers/WorkerAnimationController.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/workers/WorkerAnimationController.cpp
@@ -69,6 +69,7 @@ bool WorkerAnimationController::virtualHasPendingActivity() const
 void WorkerAnimationController::stop()
 {
     m_animationTimer.stop();
+    m_animationCallbacks.clear();
 }
 
 void WorkerAnimationController::suspend(ReasonForSuspension)


### PR DESCRIPTION
Clean backport

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313711](https://bugs.openjdk.org/browse/JDK-8313711): Cherry-pick WebKit 616.1 stabilization fixes (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx21u.git pull/6/head:pull/6` \
`$ git checkout pull/6`

Update a local copy of the PR: \
`$ git checkout pull/6` \
`$ git pull https://git.openjdk.org/jfx21u.git pull/6/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6`

View PR using the GUI difftool: \
`$ git pr show -t 6`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx21u/pull/6.diff">https://git.openjdk.org/jfx21u/pull/6.diff</a>

</details>
