### PR TITLE
8313900: Possible NULL pointer access in NativeAudioSpectrum and NativeVideoBuffer

### DIFF
--- a/modules/javafx.media/src/main/native/jfxmedia/jni/NativeAudioSpectrum.cpp
+++ b/modules/javafx.media/src/main/native/jfxmedia/jni/NativeAudioSpectrum.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,6 +55,10 @@ Java_com_sun_media_jfxmediaimpl_NativeAudioSpectrum_nativeSetBands(JNIEnv *env, 
 {
     CAudioSpectrum *pSpectrum = (CAudioSpectrum*)jlong_to_ptr(nativeRef);
     CJavaBandsHolder *pHolder = new (std::nothrow) CJavaBandsHolder();
+    if (pHolder == NULL) {
+        return;
+    }
+
     if (!pHolder->Init(env, bands, magnitudes, phases)) {
         delete pHolder;
         pHolder = NULL;

--- a/modules/javafx.media/src/main/native/jfxmedia/jni/NativeVideoBuffer.cpp
+++ b/modules/javafx.media/src/main/native/jfxmedia/jni/NativeVideoBuffer.cpp
@@ -206,7 +206,14 @@ JNIEXPORT jintArray JNICALL Java_com_sun_media_jfxmediaimpl_NativeVideoBuffer_na
         }
 
         jintArray strides = env->NewIntArray(count);
-        jint *strideArray = new jint[count];
+        if (strides == NULL) {
+            return NULL;
+        }
+
+        jint *strideArray = new (std::nothrow) jint[count];
+        if (strideArray == NULL) {
+            return NULL;
+        }
 
         for (int ii=0; ii < count; ii++) {
             strideArray[ii] = frame->GetStrideForPlane(ii);


### PR DESCRIPTION
This is clean backport of JDK-8313900.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313900](https://bugs.openjdk.org/browse/JDK-8313900): Possible NULL pointer access in NativeAudioSpectrum and NativeVideoBuffer (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx21u.git pull/7/head:pull/7` \
`$ git checkout pull/7`

Update a local copy of the PR: \
`$ git checkout pull/7` \
`$ git pull https://git.openjdk.org/jfx21u.git pull/7/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7`

View PR using the GUI difftool: \
`$ git pr show -t 7`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx21u/pull/7.diff">https://git.openjdk.org/jfx21u/pull/7.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx21u/pull/7#issuecomment-1670372759)