### PR TITLE
8314212: Crash when loading cnn.com in WebView

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/MediaPlayerPrivateJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/MediaPlayerPrivateJava.cpp
@@ -430,6 +430,12 @@ float MediaPlayerPrivate::currentTime() const
         LOG_TRACE1("MediaPlayerPrivate currentTime returns (seekTime): %f\n", m_seekTime);
         return m_seekTime;
     }
+
+    // in case of hls media m3u8 format check network state
+    // since jfx media do not support hls live streaming protocol
+    if (MediaPlayerNetworkState::NetworkError == MediaPlayer::NetworkState::NetworkError)
+        return MediaTime::zeroTime().toFloat();
+
     JNIEnv* env = WTF::GetJavaEnv();
     static jmethodID s_mID
         = env->GetMethodID(PG_GetMediaPlayerClass(env), "fwkGetCurrentTime", "()F");

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -1196,6 +1196,11 @@ void RenderLayerCompositor::computeCompositingRequirements(RenderLayer* ancestor
 #endif
     }
 
+// in case of video data format like m3u8 error case ,check if layer needs compositing
+#if PLATFORM(JAVA)
+    if (willBeComposited != needsToBeComposited(layer, queryData))
+        return;
+#endif
     ASSERT(willBeComposited == needsToBeComposited(layer, queryData));
 
     // Create or destroy backing here. However, we can't update geometry because layers above us may become composited


### PR DESCRIPTION
A clean backport to jfx21u. The fix is for the cnn.com web page crash issue, without the fix, the page crashes. I have tested the fix it is working with the fix and failing without the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314212](https://bugs.openjdk.org/browse/JDK-8314212): Crash when loading cnn.com in WebView (**Bug** - P2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx21u.git pull/10/head:pull/10` \
`$ git checkout pull/10`

Update a local copy of the PR: \
`$ git checkout pull/10` \
`$ git pull https://git.openjdk.org/jfx21u.git pull/10/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10`

View PR using the GUI difftool: \
`$ git pr show -t 10`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx21u/pull/10.diff">https://git.openjdk.org/jfx21u/pull/10.diff</a>

</details>
