### PR TITLE
8315870: icu fails to compile with Visual Studio 2022 17.6.5

### DIFF
--- a/modules/javafx.web/src/main/native/Source/ThirdParty/icu/source/i18n/fmtable.cpp
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/icu/source/i18n/fmtable.cpp
@@ -56,7 +56,7 @@ using number::impl::DecimalQuantity;
 // Return true if *a == *b.
 static inline UBool objectEquals(const UObject* a, const UObject* b) {
     // LATER: return *a == *b;
-    return *((const Measure*) a) == *((const Measure*) b);
+    return *((const Measure*) a) == *b;
 }
 
 // Return a clone of *a.


### PR DESCRIPTION
Clean backport to jfx21u.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315870](https://bugs.openjdk.org/browse/JDK-8315870) needs maintainer approval

### Issue
 * [JDK-8315870](https://bugs.openjdk.org/browse/JDK-8315870): icu fails to compile with Visual Studio 2022 17.6.5 (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx21u.git pull/14/head:pull/14` \
`$ git checkout pull/14`

Update a local copy of the PR: \
`$ git checkout pull/14` \
`$ git pull https://git.openjdk.org/jfx21u.git pull/14/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14`

View PR using the GUI difftool: \
`$ git pr show -t 14`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx21u/pull/14.diff">https://git.openjdk.org/jfx21u/pull/14.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx21u/pull/14#issuecomment-1714343621)