### PR TITLE
8315958: Missing range checks in GlassPasteboard

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/ios/GlassPasteboard.m
+++ b/modules/javafx.graphics/src/main/native-glass/ios/GlassPasteboard.m
@@ -93,11 +93,12 @@ static inline void DumpPasteboard(UIPasteboard *pasteboard)
 }
 #endif //VERBOSE
 
-static inline jbyteArray ByteArrayFromPixels(JNIEnv *env, void *data, int width, int height)
+static inline jbyteArray ByteArrayFromPixels(JNIEnv *env, void *data, size_t width, size_t height)
 {
     jbyteArray javaArray = NULL;
 
-    if ((data != NULL) && (width > 0) && (height > 0))
+    if ((data != NULL) && (width > 0) && (height > 0) &&
+        (width <= ((INT_MAX / 4) - 2) / height))
     {
         javaArray = (*env)->NewByteArray(env, 4*(width*height) + 4*(1+1));
         GLASS_CHECK_EXCEPTION(env);
@@ -364,7 +365,13 @@ JNIEXPORT jbyteArray JNICALL Java_com_sun_glass_ui_ios_IosPasteboard__1getItemAs
 
             size_t width = CGImageGetWidth(cgImage);
             size_t height = CGImageGetHeight(cgImage);
-            uint32_t *pixels = malloc(4*width*height);
+            uint32_t *pixels = NULL;
+            if (width > 0 && height > 0 &&
+                width <= (INT_MAX / 4) / height)
+            {
+                pixels = malloc(4 * width * height);
+            }
+
             if (pixels != NULL)
             {
                 CGColorSpaceRef space = CGColorSpaceCreateDeviceRGB();

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassPasteboard.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassPasteboard.m
@@ -144,7 +144,8 @@ static inline jbyteArray ByteArrayFromPixels(JNIEnv *env, void *data, size_t wid
 {
     jbyteArray javaArray = NULL;
 
-    if (data != NULL)
+    if ((data != NULL) && (width > 0) && (height > 0) &&
+        (width <= ((INT_MAX / 4) - 2) / height))
     {
         jsize length = 4*(jsize)(width*height);
 
@@ -624,7 +625,13 @@ JNIEXPORT jbyteArray JNICALL Java_com_sun_glass_ui_mac_MacPasteboard__1getItemAs
 
                     size_t width = CGImageGetWidth(cgImage);
                     size_t height = CGImageGetHeight(cgImage);
-                    uint32_t *pixels = malloc(4*width*height);
+                    uint32_t *pixels = NULL;
+                    if (width > 0 && height > 0 &&
+                        width <= (INT_MAX / 4) / height)
+                    {
+                        pixels = malloc(4 * width * height);
+                    }
+
                     if (pixels != NULL)
                     {
                         CGColorSpaceRef space = CGColorSpaceCreateDeviceRGB();


### PR DESCRIPTION
Clean backport to jfx12u.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315958](https://bugs.openjdk.org/browse/JDK-8315958) needs maintainer approval

### Issue
 * [JDK-8315958](https://bugs.openjdk.org/browse/JDK-8315958): Missing range checks in GlassPasteboard (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx21u.git pull/16/head:pull/16` \
`$ git checkout pull/16`

Update a local copy of the PR: \
`$ git checkout pull/16` \
`$ git pull https://git.openjdk.org/jfx21u.git pull/16/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16`

View PR using the GUI difftool: \
`$ git pr show -t 16`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx21u/pull/16.diff">https://git.openjdk.org/jfx21u/pull/16.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx21u/pull/16#issuecomment-1717961569)