### PR TITLE
8317842: Create release notes for JavaFX 21.0.1

### DIFF
--- a/doc-files/release-notes-21.0.1.md
+++ b/doc-files/release-notes-21.0.1.md
@@ -1,0 +1,18 @@
+# Release Notes for JavaFX 21.0.1
+
+## Introduction
+
+The following notes describe important changes and information about this release. In some cases, the descriptions provide links to additional detailed information about an issue or a change.
+
+These notes document the JavaFX 21.0.1 update release. As such, they complement the [JavaFX 21](https://github.com/openjdk/jfx21u/blob/master/doc-files/release-notes-21.md) release notes.
+
+## List of Fixed Bugs
+
+Issue key|Summary|Subcomponent
+---------|-------|------------
+[JDK-8313856](URL/JDK-8313856)|Replace VLA with malloc in pango|graphics
+[JDK-8313900](URL/JDK-8313900)|Possible NULL pointer access in NativeAudioSpectrum and NativeVideoBuffer|media
+[JDK-8310681](URL/JDK-8310681)|Update WebKit to 616.1|web
+[JDK-8311097](URL/JDK-8311097)|Synchron XMLHttpRequest not receiving data|web
+[JDK-8314212](URL/JDK-8314212)|Crash when loading cnn.com in WebView|web
+[JDK-8315657](URL/JDK-8315657)|Application window not activated in macOS 14 Sonoma|window-toolkit


### PR DESCRIPTION
Release notes for JavaFX 21.0.1.

Notes to reviewers:

I used the following filter to pick the issues:

https://bugs.openjdk.org/issues/?filter=44663

The original filter, with the backport IDs, is here:

https://bugs.openjdk.org/issues/?filter=44662

As usual, I excluded test bugs, cleanup bugs, etc. I manually excludes 4 additional bugs, one of which was a README change (does not affect the product), and the other three were introduced and fixed in the same release.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8317842](https://bugs.openjdk.org/browse/JDK-8317842) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317842](https://bugs.openjdk.org/browse/JDK-8317842): Create release notes for JavaFX 21.0.1 (**Task** - P3 - Approved)


### Reviewers
 * [Johan Vos](https://openjdk.org/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx21u.git pull/19/head:pull/19` \
`$ git checkout pull/19`

Update a local copy of the PR: \
`$ git checkout pull/19` \
`$ git pull https://git.openjdk.org/jfx21u.git pull/19/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19`

View PR using the GUI difftool: \
`$ git pr show -t 19`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx21u/pull/19.diff">https://git.openjdk.org/jfx21u/pull/19.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx21u/pull/19#issuecomment-1766498755)