### PR TITLE
8313321: Set minimum python version in WebKit cmake scripts

### DIFF
--- a/modules/javafx.web/src/main/native/Source/cmake/WebKitCommon.cmake
+++ b/modules/javafx.web/src/main/native/Source/cmake/WebKitCommon.cmake
@@ -189,10 +189,24 @@ if (NOT HAS_RUN_WEBKIT_COMMON)
     find_package(Perl 5.10.0 REQUIRED)
     find_package(PerlModules COMPONENTS English FindBin JSON::PP REQUIRED)
 
-    # This module looks preferably for version 3 of Python. If not found, version 2 is searched.
-    find_package(Python COMPONENTS Interpreter REQUIRED)
-    # Set the variable with uppercase name to keep compatibility with code and users expecting it.
-    set(PYTHON_EXECUTABLE ${Python_EXECUTABLE} CACHE FILEPATH "Path to the Python interpreter")
+    # This module looks preferably for version 3 of Python.
+    if (CMAKE_SYSTEM_NAME MATCHES "Windows")
+        find_package(Python3 3.8.0 REQUIRED)
+        find_package(Python3 COMPONENTS Interpreter REQUIRED)
+        # Set the variable with uppercase name to keep compatibility with code and users expecting it.
+        set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE} CACHE FILEPATH "Path to the Python interpreter")
+        if (NOT PYTHON_EXECUTABLE OR Python3_VERSION VERSION_LESS 3.8.0)
+           message(FATAL_ERROR "Python 3.8 or higher is required.")
+        endif ()
+    else ()
+        find_package(Python3 3.6.0 REQUIRED)
+        find_package(Python3 COMPONENTS Interpreter REQUIRED)
+        # Set the variable with uppercase name to keep compatibility with code and users expecting it.
+        set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE} CACHE FILEPATH "Path to the Python interpreter")
+        if (NOT PYTHON_EXECUTABLE OR Python3_VERSION VERSION_LESS 3.6.0)
+            message(FATAL_ERROR "Python 3.6 or higher is required.")
+        endif ()
+    endif ()
 
     # We cannot check for RUBY_FOUND because it is set only when the full package is installed and
     # the only thing we need is the interpreter. Unlike Python, cmake does not provide a macro


### PR DESCRIPTION
Set minimum python version for all platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8313321](https://bugs.openjdk.org/browse/JDK-8313321) needs maintainer approval

### Issue
 * [JDK-8313321](https://bugs.openjdk.org/browse/JDK-8313321): Set minimum python version in WebKit cmake scripts (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx21u.git pull/20/head:pull/20` \
`$ git checkout pull/20`

Update a local copy of the PR: \
`$ git checkout pull/20` \
`$ git pull https://git.openjdk.org/jfx21u.git pull/20/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20`

View PR using the GUI difftool: \
`$ git pr show -t 20`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx21u/pull/20.diff">https://git.openjdk.org/jfx21u/pull/20.diff</a>

</details>
