### PR TITLE
8319231: Unrecognized "minimum" key in .jcheck/conf causes /reviewers command to be ignored

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -40,7 +40,7 @@ domain=openjdk.org
 files=.*\.java$|.*\.c$|.*\.h$|.*\.cpp$|.*\.hpp$|.*\.cc$|.*\.jsl$|.*\.fxml$|.*\.css$|.*\.m$|.*\.mm$|.*\.frag$|.*\.vert$|.*\.hlsl$|.*\.metal$|.*\.gradle$|.*\.groovy$|.*\.g4$|.*\.stg$
 
 [checks "reviewers"]
-minimum=1
+reviewers=1
 
 [checks "merge"]
 message=Merge


### PR DESCRIPTION
Clean backport to jfx21u.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8319231](https://bugs.openjdk.org/browse/JDK-8319231) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319231](https://bugs.openjdk.org/browse/JDK-8319231): Unrecognized "minimum" key in .jcheck/conf causes /reviewers command to be ignored (**Bug** - P2 - Approved)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx21u.git pull/24/head:pull/24` \
`$ git checkout pull/24`

Update a local copy of the PR: \
`$ git checkout pull/24` \
`$ git pull https://git.openjdk.org/jfx21u.git pull/24/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24`

View PR using the GUI difftool: \
`$ git pr show -t 24`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx21u/pull/24.diff">https://git.openjdk.org/jfx21u/pull/24.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx21u/pull/24#issuecomment-1789281657)