### PR TITLE
8319079: Missing range checks in decora

### DIFF
--- a/modules/javafx.graphics/src/main/native-decora/SSEBoxBlurPeer.cc
+++ b/modules/javafx.graphics/src/main/native-decora/SSEBoxBlurPeer.cc
@@ -38,6 +38,13 @@ Java_com_sun_scenario_effect_impl_sw_sse_SSEBoxBlurPeer_filterHorizontal
      jintArray dstPixels_arr, jint dstw, jint dsth, jint dstscan,
      jintArray srcPixels_arr, jint srcw, jint srch, jint srcscan)
 {
+    if ((checkRange(env,
+                    dstPixels_arr, dstw, dsth,
+                    srcPixels_arr, srcw, srch)) ||
+        dsth > srch) { // We should not move out of source vertical bounds
+        return;
+    }
+
     jint *srcPixels = (jint *)env->GetPrimitiveArrayCritical(srcPixels_arr, 0);
     if (srcPixels == NULL) return;
     jint *dstPixels = (jint *)env->GetPrimitiveArrayCritical(dstPixels_arr, 0);
@@ -89,6 +96,13 @@ Java_com_sun_scenario_effect_impl_sw_sse_SSEBoxBlurPeer_filterVertical
      jintArray dstPixels_arr, jint dstw, jint dsth, jint dstscan,
      jintArray srcPixels_arr, jint srcw, jint srch, jint srcscan)
 {
+    if ((checkRange(env,
+                    dstPixels_arr, dstw, dsth,
+                    srcPixels_arr, srcw, srch)) ||
+        dstw > srcw) { // We should not move out of source horizontal bounds
+        return;
+    }
+
     jint *srcPixels = (jint *)env->GetPrimitiveArrayCritical(srcPixels_arr, 0);
     if (srcPixels == NULL) return;
     jint *dstPixels = (jint *)env->GetPrimitiveArrayCritical(dstPixels_arr, 0);
@@ -149,6 +163,13 @@ Java_com_sun_scenario_effect_impl_sw_sse_SSEBoxBlurPeer_filterTranspose
      jintArray srcPixels_arr, jint srcw, jint srch, jint srcscan,
      jint ksize)
 {
+    if ((checkRange(env,
+                    dstPixels_arr, dstw, dsth,
+                    srcPixels_arr, srcw, srch)) ||
+        dstw > srcw) { // We should not move out of source horizontal bounds
+        return;
+    }
+
     jint *srcPixels = (jint *)env->GetPrimitiveArrayCritical(srcPixels_arr, 0);
     if (srcPixels == NULL) return;
     jint *dstPixels = (jint *)env->GetPrimitiveArrayCritical(dstPixels_arr, 0);

--- a/modules/javafx.graphics/src/main/native-decora/SSEBoxShadowPeer.cc
+++ b/modules/javafx.graphics/src/main/native-decora/SSEBoxShadowPeer.cc
@@ -39,6 +39,13 @@ Java_com_sun_scenario_effect_impl_sw_sse_SSEBoxShadowPeer_filterHorizontalBlack
      jintArray srcPixels_arr, jint srcw, jint srch, jint srcscan,
      jfloat spread)
 {
+    if ((checkRange(env,
+                    dstPixels_arr, dstw, dsth,
+                    srcPixels_arr, srcw, srch)) ||
+        dsth > srch) { // We should not move out of source vertical bounds
+        return;
+    }
+
     jint *srcPixels = (jint *)env->GetPrimitiveArrayCritical(srcPixels_arr, 0);
     if (srcPixels == NULL) return;
     jint *dstPixels = (jint *)env->GetPrimitiveArrayCritical(dstPixels_arr, 0);
@@ -86,6 +93,13 @@ Java_com_sun_scenario_effect_impl_sw_sse_SSEBoxShadowPeer_filterVerticalBlack
      jintArray srcPixels_arr, jint srcw, jint srch, jint srcscan,
      jfloat spread)
 {
+    if ((checkRange(env,
+                    dstPixels_arr, dstw, dsth,
+                    srcPixels_arr, srcw, srch)) ||
+        dstw > srcw) { // We should not move out of source horizontal bounds
+        return;
+    }
+
     jint *srcPixels = (jint *)env->GetPrimitiveArrayCritical(srcPixels_arr, 0);
     if (srcPixels == NULL) return;
     jint *dstPixels = (jint *)env->GetPrimitiveArrayCritical(dstPixels_arr, 0);
@@ -134,6 +148,13 @@ Java_com_sun_scenario_effect_impl_sw_sse_SSEBoxShadowPeer_filterVertical
      jintArray srcPixels_arr, jint srcw, jint srch, jint srcscan,
      jfloat spread, jfloatArray shadowColor_arr)
 {
+    if ((checkRange(env,
+                    dstPixels_arr, dstw, dsth,
+                    srcPixels_arr, srcw, srch)) ||
+        dstw > srcw) { // We should not move out of source horizontal bounds
+        return;
+    }
+
     jfloat shadowColor[4];
     env->GetFloatArrayRegion(shadowColor_arr, 0, 4, shadowColor);
 

--- a/modules/javafx.graphics/src/main/native-decora/SSELinearConvolvePeer.cc
+++ b/modules/javafx.graphics/src/main/native-decora/SSELinearConvolvePeer.cc
@@ -110,6 +110,13 @@ Java_com_sun_scenario_effect_impl_sw_sse_SSELinearConvolvePeer_filterHV
      jintArray srcPixels_arr, jint srccols, jint srcrows, jint scolinc, jint srowinc,
      jfloatArray kvals_arr)
 {
+    if ((checkRange(env,
+                    dstPixels_arr, dstcols, dstrows,
+                    srcPixels_arr, srccols, srcrows)) ||
+        dstrows > srcrows) { // We should not move out of source vertical bounds
+        return;
+    }
+
     jint kernelSize = env->GetArrayLength(kvals_arr) / 2;
     if (kernelSize > 128) return;
     jfloat kvals[256];

--- a/modules/javafx.graphics/src/main/native-decora/SSELinearConvolveShadowPeer.cc
+++ b/modules/javafx.graphics/src/main/native-decora/SSELinearConvolveShadowPeer.cc
@@ -118,6 +118,13 @@ Java_com_sun_scenario_effect_impl_sw_sse_SSELinearConvolveShadowPeer_filterHV
      jintArray srcPixels_arr, jint srccols, jint srcrows, jint scolinc, jint srowinc,
      jfloatArray kvals_arr, jfloatArray shadowColor_arr)
 {
+    if ((checkRange(env,
+                    dstPixels_arr, dstcols, dstrows,
+                    srcPixels_arr, srccols, srcrows)) ||
+        dstrows > srcrows) { // We should not move out of source vertical bounds
+        return;
+    }
+
     jint kernelSize = env->GetArrayLength(kvals_arr) / 2;
     if (kernelSize > 128) return;
     jfloat kvals[256];

--- a/modules/javafx.graphics/src/main/native-decora/SSEUtils.cc
+++ b/modules/javafx.graphics/src/main/native-decora/SSEUtils.cc
@@ -183,3 +183,24 @@ void fsample(jfloat *map,
         }
     }
 }
+
+/*
+ * checkRange function returns true if source or destination
+ * dimensions are not in the required bounds and returns false
+ * if dimensions are within required bounds.
+ */
+bool checkRange(JNIEnv *env,
+                jintArray dstPixels_arr, jint dstw, jint dsth,
+                jintArray srcPixels_arr, jint srcw, jint srch)
+{
+    return (srcPixels_arr == NULL ||
+            dstPixels_arr == NULL ||
+            srcw <= 0 ||
+            srch <= 0 ||
+            srcw > INT_MAX / srch ||
+            dstw <= 0 ||
+            dsth <= 0 ||
+            dstw > INT_MAX / dsth ||
+            (srcw * srch) > env->GetArrayLength(srcPixels_arr) ||
+            (dstw * dsth) > env->GetArrayLength(dstPixels_arr));
+}

--- a/modules/javafx.graphics/src/main/native-decora/SSEUtils.h
+++ b/modules/javafx.graphics/src/main/native-decora/SSEUtils.h
@@ -38,6 +38,10 @@ extern "C" {
 #define FVAL_G   1
 #define FVAL_B   2
 
+#ifndef INT_MAX
+#define INT_MAX 2147483647
+#endif /* INT_MAX */
+
 void lsample(jint *img,
              jfloat floc_x, jfloat floc_y,
              jint w, jint h, jint scan,
@@ -52,6 +56,10 @@ void fsample(jfloat *img,
              jfloat floc_x, jfloat floc_y,
              jint w, jint h, jint scan,
              jfloat *fvals);
+
+bool checkRange(JNIEnv *env,
+                jintArray dstPixels_arr, jint dstw, jint dsth,
+                jintArray srcPixels_arr, jint srcw, jint srch);
 
 #ifdef __cplusplus
 };


### PR DESCRIPTION
This is jfx21u backport of https://bugs.openjdk.org/browse/JDK-8319079
It adds appropriate range checks in native code for Box/Gaussian Blur/Shadow effects in Software pipeline.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8319079](https://bugs.openjdk.org/browse/JDK-8319079) needs maintainer approval

### Issue
 * [JDK-8319079](https://bugs.openjdk.org/browse/JDK-8319079): Missing range checks in decora (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx21u.git pull/25/head:pull/25` \
`$ git checkout pull/25`

Update a local copy of the PR: \
`$ git checkout pull/25` \
`$ git pull https://git.openjdk.org/jfx21u.git pull/25/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25`

View PR using the GUI difftool: \
`$ git pr show -t 25`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx21u/pull/25.diff">https://git.openjdk.org/jfx21u/pull/25.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx21u/pull/25#issuecomment-1791076306)