### PR TITLE
8319669: [macos14] Running any JavaFX app prints Secure coding warning

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.h
@@ -31,6 +31,19 @@
 
 @end
 
+
+/*
+ * NSApplicationFX is a subclass of NSApplication that we use when we
+ * initialize the application.
+ * We need to subclass NSApplication in order to stop AWT from installing
+ * their NSApplicationDelegate delegate, overwriting the one we install.
+ *
+ * We don't override anything in NSApplication. All work is done in our
+ * NSApplicationDelegate as recommended by Apple.
+ */
+@interface NSApplicationFX : NSApplication
+@end
+
 @interface GlassApplication : NSObject <NSApplicationDelegate>
 {
     BOOL            started;

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
@@ -115,6 +115,9 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
 
 @end
 
+@implementation NSApplicationFX
+@end
+
 #pragma mark --- GlassApplication
 
 @implementation GlassApplication
@@ -226,6 +229,10 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
     }
     [pool drain];
     GLASS_CHECK_EXCEPTION(env);
+}
+
+- (BOOL)applicationSupportsSecureRestorableState:(NSApplication *)app {
+    return YES;
 }
 
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification
@@ -532,8 +539,8 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
         }
 
         // Determine if we're running embedded (in AWT, SWT, elsewhere)
-        NSApplication *app = [NSApplication sharedApplication];
-        isEmbedded = [app isRunning];
+        NSApplication *app = [NSApplicationFX sharedApplication];
+        isEmbedded = ![app isKindOfClass:[NSApplicationFX class]];
 
         if (!isEmbedded)
         {


### PR DESCRIPTION
Clean backport of critical macOS 14 fix to 21u.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8319669](https://bugs.openjdk.org/browse/JDK-8319669) needs maintainer approval

### Issue
 * [JDK-8319669](https://bugs.openjdk.org/browse/JDK-8319669): [macos14] Running any JavaFX app prints Secure coding warning (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx21u.git pull/28/head:pull/28` \
`$ git checkout pull/28`

Update a local copy of the PR: \
`$ git checkout pull/28` \
`$ git pull https://git.openjdk.org/jfx21u.git pull/28/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 28`

View PR using the GUI difftool: \
`$ git pr show -t 28`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx21u/pull/28.diff">https://git.openjdk.org/jfx21u/pull/28.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx21u/pull/28#issuecomment-1812614487)