### PR TITLE
8317370: JavaFX runtime version is wrong at runtime

### DIFF
--- a/UPDATING-VERSION.md
+++ b/UPDATING-VERSION.md
@@ -24,7 +24,7 @@ feature version number from `N` to `N+1`:
 
 * In
 `modules/javafx.base/src/test/java/test/com/sun/javafx/runtime/VersionInfoTest.java`,
-modify the testMajorVersion method to increment the feature version number
+modify the `FEATURE` variable to increment the feature version number
 from `N` to `N+1`.
 
 ## Incrementing the security version

--- a/build.gradle
+++ b/build.gradle
@@ -638,19 +638,20 @@ if (sourceDateEpoch != null) {
     def epochSeconds = Long.parseLong(sourceDateEpoch)
     buildInstant = Instant.ofEpochSecond(epochSeconds)
 }
-// Creates the timestamp in UTC using the ISO 8601 extended format
-def buildTimestamp = buildInstant.toString()
+// Creates the timestamp in UTC using the ISO 8601 extended format.
+def extendedTimestamp = buildInstant.toString()
+// Creates the timestamp in UTC using the historical ad hoc format, which is
+// valid for the OPT field of the version string. An alternative to the ad hoc
+// format is the ISO 8601 basic format with the pattern "yyyyMMdd'T'HHmmssX".
+def zonedTime = ZonedDateTime.ofInstant(buildInstant, ZoneOffset.UTC)
+def formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd-HHmmss")
+def buildTimestamp = zonedTime.format(formatter)
 defineProperty("BUILD_TIMESTAMP", buildTimestamp)
 def relSuffix = ""
 def relOpt = ""
 if (HUDSON_JOB_NAME == "not_hudson") {
-    // The version OPT field matches the regular expression "([-a-zA-Z0-9.]+)".
-    // For the ISO 8601 basic format, use the pattern "yyyyMMdd'T'HHmmssX".
-    def zonedTime = ZonedDateTime.ofInstant(buildInstant, ZoneOffset.UTC)
-    def formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd-HHmmss")
-    String versionTimestamp = zonedTime.format(formatter)
     relSuffix = "-internal"
-    relOpt = "-${versionTimestamp}"
+    relOpt = "-${buildTimestamp}"
 } else {
     relSuffix = IS_MILESTONE_FCS ? "" : jfxReleaseSuffix
 }
@@ -2187,10 +2188,9 @@ project(":base") {
         "BUILD_TIMESTAMP": BUILD_TIMESTAMP,
         "HUDSON_JOB_NAME": HUDSON_JOB_NAME,
         "HUDSON_BUILD_NUMBER": HUDSON_BUILD_NUMBER,
-        "PROMOTED_BUILD_NUMBER": PROMOTED_BUILD_NUMBER,
-        "PRODUCT_NAME": PRODUCT_NAME,
-        "RELEASE_VERSION": RELEASE_VERSION,
-        "RELEASE_SUFFIX": RELEASE_SUFFIX];
+        "RELEASE_SUFFIX": RELEASE_SUFFIX,
+        "RELEASE_VERSION_SHORT": RELEASE_VERSION_SHORT,
+        "RELEASE_VERSION_LONG": RELEASE_VERSION_LONG];
     task processVersionInfo(type: Copy, description: "Replace params in VersionInfo and copy file to destination") {
         doFirst { mkdir "$buildDir/gensrc/java" }
         from "src/main/version-info"
@@ -5667,7 +5667,7 @@ compileTargets { t ->
                         // https://bugs.openjdk.org/browse/JDK-8278766
                         def status = compareJdkVersion(jdkVersion, "19")
                         if (sourceDateEpoch != null && status >= 0) {
-                            args("--date", buildTimestamp)
+                            args("--date", extendedTimestamp)
                         }
                         args(jmodFile)
                     }

--- a/modules/javafx.base/src/main/version-info/VersionInfo.java
+++ b/modules/javafx.base/src/main/version-info/VersionInfo.java
@@ -97,50 +97,19 @@ public class VersionInfo {
     private static final String HUDSON_BUILD_NUMBER = "@HUDSON_BUILD_NUMBER@";
 
     /**
-     * Promoted build number used as part of the runtime version string.
-     */
-    private static final String PROMOTED_BUILD_NUMBER = "@PROMOTED_BUILD_NUMBER@";
-
-    /**
-     * Raw Version number string. (without milestone tag)
-     */
-    private static final String RELEASE_VERSION = "@RELEASE_VERSION@";
-
-    /**
      * Release suffix.
      */
     private static final String RELEASE_SUFFIX = "@RELEASE_SUFFIX@";
 
     /**
-     * The composite version string. This is composed in the static
-     * initializer for this class.
+     * The composite version string.
      */
-    private static final String VERSION;
+    private static final String VERSION = "@RELEASE_VERSION_SHORT@";
 
     /**
      * The composite version string include build number.
-     * This is composed in the static initializer for this class.
      */
-    private static final String RUNTIME_VERSION;
-
-    // The static initializer composes the VERSION and RUNTIME_VERSION strings
-    static {
-        String tmpVersion = RELEASE_VERSION;
-
-        // Construct the VERSION string adding milestone information,
-        // such as beta, if present.
-        // Note: RELEASE_SUFFIX is expected to be empty for fcs versions
-        tmpVersion += RELEASE_SUFFIX;
-        VERSION = tmpVersion;
-
-        // Append the RUNTIME_VERSION string that follow the VERSION string
-        tmpVersion += "+" + PROMOTED_BUILD_NUMBER;
-        if (getHudsonJobName().length() == 0) {
-            // Non hudson (developer) build
-            tmpVersion += "-" + BUILD_TIMESTAMP;
-        }
-        RUNTIME_VERSION = tmpVersion;
-    }
+    private static final String RUNTIME_VERSION = "@RELEASE_VERSION_LONG@";
 
     /**
      * Setup the System properties with JavaFX API version information.

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/runtime/VersionInfoTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/runtime/VersionInfoTest.java
@@ -26,12 +26,29 @@
 package test.com.sun.javafx.runtime;
 
 import com.sun.javafx.runtime.VersionInfo;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.Properties;
+import org.junit.Before;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
 /**
  */
 public class VersionInfoTest {
+
+    // Increment this feature-release counter for every major release.
+    private static final String FEATURE = "21";
+
+    // The working directory at runtime is 'modules/javafx.base'.
+    private static final String PROPERTIES_FILE = "build/module-lib/javafx.properties";
+    private static final String VERSION_KEY = "javafx.version";
+    private static final String RUNTIME_VERSION_KEY = "javafx.runtime.version";
+
+    // See 'java.lang.Runtime.Version' for the format of a short version string.
+    private static final String VNUM = "[1-9][0-9]*((\\.0)*\\.[1-9][0-9]*)*";
+    private static final String PRE = "([a-zA-Z0-9]+)";
+    private static final String SVSTR = String.format("%s(-%s)?", VNUM, PRE);
 
     private static class Version {
         private String vnum = "";
@@ -84,12 +101,23 @@ public class VersionInfoTest {
         }
     }
 
+    private final Properties properties;
+
+    public VersionInfoTest() {
+        properties = new Properties();
+    }
+
+    @Before
+    public void setup() throws IOException {
+        try (var reader = new FileReader(PROPERTIES_FILE)) {
+            properties.load(reader);
+        }
+    }
+
     @Test
     public void testMajorVersion() {
         String version = VersionInfo.getVersion();
-        // Need to update major version number when we develop the next
-        // major release.
-        assertTrue(version.startsWith("21"));
+        assertTrue(version.startsWith(FEATURE));
         String runtimeVersion = VersionInfo.getRuntimeVersion();
         assertTrue(runtimeVersion.startsWith(version));
     }
@@ -148,4 +176,34 @@ public class VersionInfoTest {
         }
     }
 
+    @Test
+    public void testVersionFormat() {
+        String version = VersionInfo.getVersion();
+        String message = String.format("Wrong short version string: '%s'", version);
+        assertTrue(message, version.matches(SVSTR));
+    }
+
+    @Test
+    public void testRuntimeVersionFormat() {
+        String runtimeVersion = VersionInfo.getRuntimeVersion();
+        try {
+            Runtime.Version.parse(runtimeVersion);
+        } catch (IllegalArgumentException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testVersionInFile() {
+        String versionLive = VersionInfo.getVersion();
+        String versionFile = properties.getProperty(VERSION_KEY);
+        assertEquals(versionLive, versionFile);
+    }
+
+    @Test
+    public void testRuntimeVersionInFile() {
+        String runtimeVersionLive = VersionInfo.getRuntimeVersion();
+        String runtimeVersionFile = properties.getProperty(RUNTIME_VERSION_KEY);
+        assertEquals(runtimeVersionLive, runtimeVersionFile);
+    }
 }


### PR DESCRIPTION
Backport 16169240667876633895b27464eb90033abb6166

Please review this backport of openjdk/jfx#1253 to JavaFX 21. Please give me a day or two to test it again before starting your review.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8317370](https://bugs.openjdk.org/browse/JDK-8317370) needs maintainer approval

### Issue
 * [JDK-8317370](https://bugs.openjdk.org/browse/JDK-8317370): JavaFX runtime version is wrong at runtime (**Bug** - P3 - Approved)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx21u.git pull/32/head:pull/32` \
`$ git checkout pull/32`

Update a local copy of the PR: \
`$ git checkout pull/32` \
`$ git pull https://git.openjdk.org/jfx21u.git pull/32/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32`

View PR using the GUI difftool: \
`$ git pr show -t 32`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx21u/pull/32.diff">https://git.openjdk.org/jfx21u/pull/32.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx21u/pull/32#issuecomment-1821634468)