### PR TITLE
8320267: WebView crashes on macOS 11 with WebKit 616.1

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/PlatformJSCOnly.cmake
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/PlatformJSCOnly.cmake
@@ -82,7 +82,7 @@ elseif (APPLE)
             ${WTF_DERIVED_SOURCES_DIR}/mach_excUser.c
         MAIN_DEPENDENCY mac/MachExceptions.defs
         WORKING_DIRECTORY ${WTF_DERIVED_SOURCES_DIR}
-        COMMAND mig -DMACH_EXC_SERVER_TASKIDTOKEN -sheader MachExceptionsServer.h MachExceptions.defs
+        COMMAND mig -sheader MachExceptionsServer.h MachExceptions.defs
         VERBATIM)
     list(APPEND WTF_SOURCES
         cocoa/MemoryFootprintCocoa.cpp

--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/threads/Signals.cpp
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/threads/Signals.cpp
@@ -42,23 +42,19 @@ extern "C" {
 #include <dispatch/dispatch.h>
 #include <mach/mach.h>
 #include <mach/thread_act.h>
-#include <mach/thread_status.h>
 #endif
 
 #if OS(DARWIN)
 #include <mach/vm_param.h>
 #endif
 
-#include <unistd.h>
 #include <wtf/Atomics.h>
 #include <wtf/DataLog.h>
 #include <wtf/MathExtras.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/PlatformRegisters.h>
-#include <wtf/Scope.h>
 #include <wtf/ThreadGroup.h>
 #include <wtf/Threading.h>
-#include <wtf/TranslatedProcess.h>
 #include <wtf/WTFConfig.h>
 
 namespace WTF {
@@ -207,159 +203,6 @@ kern_return_t catch_mach_exception_raise_state_identity(mach_port_t, mach_port_t
     return KERN_FAILURE;
 }
 
-static kern_return_t runSignalHandlers(Signal &signal, PlatformRegisters& registers, bool &didHandle, mach_msg_type_number_t dataCount, mach_exception_data_t exceptionData)
-{
-    SigInfo info;
-    SignalHandlers& handlers = g_wtfConfig.signalHandlers;
-    if (signal == Signal::AccessFault) {
-        ASSERT_UNUSED(dataCount, dataCount == 2);
-        info.faultingAddress = reinterpret_cast<void*>(exceptionData[1]);
-#if CPU(ADDRESS64)
-        // If the faulting address is out of the range of any valid memory, we would
-        // not have any reason to handle it. Just let the default handler take care of it.
-        static constexpr unsigned validAddressBits = OS_CONSTANT(EFFECTIVE_ADDRESS_WIDTH);
-        static constexpr uintptr_t invalidAddressMask = ~((1ull << validAddressBits) - 1);
-        if (bitwise_cast<uintptr_t>(info.faultingAddress) & invalidAddressMask)
-            return KERN_FAILURE;
-#endif
-    }
-
-    handlers.forEachHandler(signal, [&] (const SignalHandler& handler) {
-        SignalAction handlerResult = handler(signal, info, registers);
-        didHandle |= handlerResult == SignalAction::Handled;
-    });
-    return KERN_SUCCESS;
-}
-
-#ifdef EXCEPTION_IDENTITY_PROTECTED
-
-static thread_act_t threadIDGetThreadPort(uint64_t threadID)
-{
-    mach_msg_type_number_t threadCount;
-    thread_act_array_t threads;
-    thread_act_t thread = THREAD_NULL;
-
-    task_threads(mach_task_self(), &threads, &threadCount);
-    for (mach_msg_type_number_t i = 0; i < threadCount; i++) {
-        if (thread != THREAD_NULL) {
-            // clean up all the remaining mach thread ports
-            ASSERT(thread != threads[i]);
-            mach_port_deallocate(mach_task_self(), threads[i]);
-            continue;
-        }
-
-        struct thread_identifier_info threadIdentifierInfo;
-        unsigned infoCount = THREAD_IDENTIFIER_INFO_COUNT;
-        kern_return_t kr = thread_info(threads[i], THREAD_IDENTIFIER_INFO,
-            reinterpret_cast<thread_info_t>(&threadIdentifierInfo), &infoCount);
-
-        if (kr == MACH_SEND_INVALID_DEST) {
-            // ignore threads that have been destroyed
-            continue;
-        }
-        if (kr != KERN_SUCCESS) {
-            dataLogLn("thread_info failed due to ", mach_error_string(kr));
-            continue;
-        }
-
-        if (threadIdentifierInfo.thread_id == threadID) {
-            // we found the thread we are looking for
-            thread = threads[i];
-            continue;
-        }
-        // clean up mach thread ports
-        mach_port_deallocate(mach_task_self(), threads[i]);
-    }
-    // clean up array
-    vm_deallocate(mach_task_self(), (vm_address_t)threads,
-        sizeof(threads[0]) * threadCount);
-    return thread;
-}
-
-kern_return_t catch_mach_exception_raise_identity_protected(
-    mach_port_t exceptionPort,
-    uint64_t threadID,
-    mach_port_t taskIDToken,
-    exception_type_t exceptionType,
-    mach_exception_data_t exceptionData,
-    mach_msg_type_number_t dataCount)
-{
-    UNUSED_PARAM(taskIDToken);
-
-    SignalHandlers& handlers = g_wtfConfig.signalHandlers;
-    RELEASE_ASSERT(exceptionPort == handlers.exceptionPort);
-    // If we wanted to distinguish between SIGBUS and SIGSEGV for EXC_BAD_ACCESS on Darwin we could do:
-    // if (exceptionData[0] == KERN_INVALID_ADDRESS)
-    //    signal = SIGSEGV;
-    // else
-    //    signal = SIGBUS;
-    Signal signal = fromMachException(exceptionType);
-    RELEASE_ASSERT(signal != Signal::Unknown);
-
-    thread_act_t thread = threadIDGetThreadPort(threadID);
-    auto clear = makeScopeExit([&] {
-        mach_port_deallocate(mach_task_self(), thread);
-    });
-
-
-    mach_msg_type_number_t stateCount = 0;
-
-#if CPU(X86_64) || CPU(X86)
-    x86_thread_state_t state;
-    int flavor = x86_THREAD_STATE;
-    stateCount = x86_THREAD_STATE_COUNT;
-#elif CPU(ARM64) || CPU(ARM)
-    arm_unified_thread_state state;
-    int flavor = ARM_THREAD_STATE;
-    stateCount = ARM_UNIFIED_THREAD_STATE_COUNT;
-#endif
-
-    kern_return_t kr = thread_get_state(thread, flavor, (thread_state_t)&state, &stateCount);
-    if (kr != KERN_SUCCESS) {
-        dataLogLn("thread_get_state failed due to ", mach_error_string(kr));
-        return kr;
-    }
-
-#if CPU(ARM64E) && OS(DARWIN)
-    ptrauth_generic_signature_t inStateHash = hashThreadState((thread_state_t)&state);
-#endif
-
-#if CPU(X86_64)
-    PlatformRegisters& registers = state.uts.ts64;
-    RELEASE_ASSERT(state.tsh.flavor == x86_THREAD_STATE64);
-#elif CPU(X86)
-    PlatformRegisters& registers = state.uts.ts32;
-    RELEASE_ASSERT(state.tsh.flavor == x86_THREAD_STATE32);
-#elif CPU(ARM64)
-    PlatformRegisters& registers = state.ts_64;
-    RELEASE_ASSERT(state.ash.flavor == ARM_THREAD_STATE64);
-#elif CPU(ARM)
-    PlatformRegisters& registers = state.ts_32;
-    RELEASE_ASSERT(state.ash.flavor == ARM_THREAD_STATE32);
-#endif
-
-    bool didHandle = false;
-    kr = runSignalHandlers(signal, registers, didHandle, dataCount, exceptionData);
-    if (kr != KERN_SUCCESS)
-        return kr;
-
-    if (didHandle) {
-#if CPU(ARM64E) && OS(DARWIN)
-        RELEASE_ASSERT(inStateHash == hashThreadState((thread_state_t)&state));
-#endif
-        kr = thread_set_state(thread, flavor, (thread_state_t)&state,
-            stateCount);
-
-        if (kr != KERN_SUCCESS)
-            dataLogLn("thread_set_state failed due to ", mach_error_string(kr));
-
-        return kr;
-    }
-    return KERN_FAILURE;
-}
-
-#endif // EXCEPTION_IDENTITY_PROTECTED
-
 kern_return_t catch_mach_exception_raise_state(
     mach_port_t port,
     exception_type_t exceptionType,
@@ -401,10 +244,25 @@ kern_return_t catch_mach_exception_raise_state(
     PlatformRegisters& registers = reinterpret_cast<arm_unified_thread_state*>(outState)->ts_32;
 #endif
 
+    SigInfo info;
+    if (signal == Signal::AccessFault) {
+        ASSERT_UNUSED(dataCount, dataCount == 2);
+        info.faultingAddress = reinterpret_cast<void*>(exceptionData[1]);
+#if CPU(ADDRESS64)
+        // If the faulting address is out of the range of any valid memory, we would
+        // not have any reason to handle it. Just let the default handler take care of it.
+        static constexpr unsigned validAddressBits = OS_CONSTANT(EFFECTIVE_ADDRESS_WIDTH);
+        static constexpr uintptr_t invalidAddressMask = ~((1ull << validAddressBits) - 1);
+        if (bitwise_cast<uintptr_t>(info.faultingAddress) & invalidAddressMask)
+            return KERN_FAILURE;
+#endif
+    }
+
     bool didHandle = false;
-    kern_return_t kr = runSignalHandlers(signal, registers, didHandle, dataCount, exceptionData);
-    if (kr != KERN_SUCCESS)
-        return kr;
+    handlers.forEachHandler(signal, [&] (const SignalHandler& handler) {
+        SignalAction handlerResult = handler(signal, info, registers);
+        didHandle |= handlerResult == SignalAction::Handled;
+    });
 
     if (didHandle) {
 #if CPU(ARM64E) && OS(DARWIN)
@@ -430,21 +288,7 @@ inline void setExceptionPorts(const AbstractLocker& threadGroupLocker, Thread& t
 {
     UNUSED_PARAM(threadGroupLocker);
     SignalHandlers& handlers = g_wtfConfig.signalHandlers;
-
-#ifdef EXCEPTION_IDENTITY_PROTECTED
-    exception_behavior_t newBehavior = MACH_EXCEPTION_CODES;
-    if (WTF::isX86BinaryRunningOnARM()) {
-        // If we are a translated process in rosetta, use the old exception style
-        newBehavior |= EXCEPTION_STATE;
-    } else {
-        // Otherwise use the new style
-        newBehavior |= EXCEPTION_IDENTITY_PROTECTED;
-    }
-#else
-    exception_behavior_t newBehavior = EXCEPTION_STATE | MACH_EXCEPTION_CODES;
-#endif // EXCEPTION_IDENTITY_PROTECTED
-
-    kern_return_t result = thread_set_exception_ports(thread.machThread(), handlers.addedExceptions &activeExceptions, handlers.exceptionPort, newBehavior, MACHINE_THREAD_STATE);
+    kern_return_t result = thread_set_exception_ports(thread.machThread(), handlers.addedExceptions &activeExceptions, handlers.exceptionPort, EXCEPTION_STATE | MACH_EXCEPTION_CODES, MACHINE_THREAD_STATE);
     if (result != KERN_SUCCESS) {
         dataLogLn("thread set port failed due to ", mach_error_string(result));
         CRASH();


### PR DESCRIPTION
Clean backport of fix for macOS 11 WebKit crash to jfx21u.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8320267](https://bugs.openjdk.org/browse/JDK-8320267) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320267](https://bugs.openjdk.org/browse/JDK-8320267): WebView crashes on macOS 11 with WebKit 616.1 (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx21u.git pull/35/head:pull/35` \
`$ git checkout pull/35`

Update a local copy of the PR: \
`$ git checkout pull/35` \
`$ git pull https://git.openjdk.org/jfx21u.git pull/35/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 35`

View PR using the GUI difftool: \
`$ git pr show -t 35`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx21u/pull/35.diff">https://git.openjdk.org/jfx21u/pull/35.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx21u/pull/35#issuecomment-1833730396)