### PR TITLE
8318708: FX: Update copyright year in docs, readme files to 2024

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -54,7 +54,7 @@ jfx.release.patch.version=0
 #
 ##############################################################################
 
-javadoc.bottom=<small><a href="http://bugreport.java.com/bugreport/">Report a bug or suggest an enhancement</a><br> Copyright &copy; 2008, 2023, Oracle and/or its affiliates. All rights reserved.</small>
+javadoc.bottom=<small><a href="http://bugreport.java.com/bugreport/">Report a bug or suggest an enhancement</a><br> Copyright &copy; 2008, 2024, Oracle and/or its affiliates. All rights reserved.</small>
 
 javadoc.title=JavaFX 21
 javadoc.header=JavaFX&nbsp;21

--- a/modules/javafx.fxml/src/main/docs/javafx/fxml/doc-files/introduction_to_fxml.html
+++ b/modules/javafx.fxml/src/main/docs/javafx/fxml/doc-files/introduction_to_fxml.html
@@ -1111,7 +1111,7 @@ module. A type is reflectively accessible if the module
 </p>
 <hr>
 <p>
-<small><a href="http://bugreport.java.com/bugreport/">Report a bug or suggest an enhancement</a><br> Copyright &copy; 2008, 2023, Oracle and/or its affiliates. All rights reserved.</small>
+<small><a href="http://bugreport.java.com/bugreport/">Report a bug or suggest an enhancement</a><br> Copyright &copy; 2008, 2024, Oracle and/or its affiliates. All rights reserved.</small>
 </p>
 </body>
 </html>

--- a/modules/javafx.graphics/src/main/docs/javafx/scene/doc-files/cssref.html
+++ b/modules/javafx.graphics/src/main/docs/javafx/scene/doc-files/cssref.html
@@ -6152,7 +6152,7 @@
     <p>[5] Uniform Resource Identifier (URI): Generic Syntax <a href="http://www.ietf.org/rfc/rfc3986">RFC-3986</a></p>
     <hr>
     <p>
-<small><a href="http://bugreport.java.com/bugreport/">Report a bug or suggest an enhancement</a><br> Copyright &copy; 2008, 2023, Oracle and/or its affiliates. All rights reserved.</small>
+<small><a href="http://bugreport.java.com/bugreport/">Report a bug or suggest an enhancement</a><br> Copyright &copy; 2008, 2024, Oracle and/or its affiliates. All rights reserved.</small>
     </p>
     <br>
   </body>


### PR DESCRIPTION
A clean backport to jfx21u, to update copyright year in doc files.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8318708](https://bugs.openjdk.org/browse/JDK-8318708) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318708](https://bugs.openjdk.org/browse/JDK-8318708): FX: Update copyright year in docs, readme files to 2024 (**Task** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx21u.git pull/36/head:pull/36` \
`$ git checkout pull/36`

Update a local copy of the PR: \
`$ git checkout pull/36` \
`$ git pull https://git.openjdk.org/jfx21u.git pull/36/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 36`

View PR using the GUI difftool: \
`$ git pr show -t 36`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx21u/pull/36.diff">https://git.openjdk.org/jfx21u/pull/36.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx21u/pull/36#issuecomment-1835896155)