### PR TITLE
8313648: JavaFX application continues to show a black screen after graphic card driver crash

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DContext.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,11 +45,13 @@ import com.sun.prism.ps.Shader;
 
 class D3DContext extends BaseShaderContext {
 
-    public static final int D3DERR_DEVICEREMOVED    = 0x88760870;
-    public static final int D3DERR_DEVICENOTRESET   = 0x88760869;
     public static final int D3DERR_DEVICELOST       = 0x88760868;
-    public static final int E_FAIL                  = 0x80004005;
+    public static final int D3DERR_DEVICENOTRESET   = 0x88760869;
+    public static final int D3DERR_DEVICEREMOVED    = 0x88760870;
+    public static final int D3DERR_DEVICEHUNG       = 0X88760874;
     public static final int D3DERR_OUTOFVIDEOMEMORY = 0x8876017c;
+
+    public static final int E_FAIL                  = 0x80004005;
     public static final int D3D_OK                  = 0x0;
 
     public static final int D3DCOMPMODE_CLEAR           = 0;
@@ -170,6 +172,9 @@ class D3DContext extends BaseShaderContext {
                 case D3DERR_DEVICENOTRESET:
                     System.err.println("D3DERR_DEVICENOTRESET");
                     break;
+                case D3DERR_DEVICEHUNG:
+                    System.err.println("D3DERR_DEVICEHUNG");
+                    break;
                 case E_FAIL:
                     System.err.println("E_FAIL");
                     break;
@@ -199,7 +204,7 @@ class D3DContext extends BaseShaderContext {
             }
         }
 
-        if (hr == D3DERR_DEVICEREMOVED) {
+        if (hr == D3DERR_DEVICEREMOVED || hr == D3DERR_DEVICEHUNG) {
             setLost();
 
             // Reinitialize the D3DPipeline. This will dispose and recreate
@@ -503,14 +508,16 @@ class D3DContext extends BaseShaderContext {
 
     public static String hResultToString(long hResult) {
         switch ((int)hResult) {
-            case D3DERR_DEVICENOTRESET:
-                return "D3DERR_DEVICENOTRESET";
             case D3DERR_DEVICELOST:
                 return "D3DERR_DEVICELOST";
-            case D3DERR_OUTOFVIDEOMEMORY:
-                return "D3DERR_OUTOFVIDEOMEMORY";
+            case D3DERR_DEVICENOTRESET:
+                return "D3DERR_DEVICENOTRESET";
             case D3DERR_DEVICEREMOVED:
                 return "D3DERR_DEVICEREMOVED";
+            case D3DERR_DEVICEHUNG:
+                return "D3DERR_DEVICEHUNG";
+            case D3DERR_OUTOFVIDEOMEMORY:
+                return "D3DERR_OUTOFVIDEOMEMORY";
             case D3D_OK:
                 return "D3D_OK";
             default:

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DContext.cc
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DContext.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -757,6 +757,9 @@ D3DContext::TestCooperativeLevel()
         break;
     case D3DERR_DEVICEREMOVED:
         TraceLn1(NWT_TRACE_INFO, "  device %d has been removed", adapterOrdinal);
+        break;
+    case D3DERR_DEVICEHUNG:
+        TraceLn1(NWT_TRACE_INFO, "  device %d is hung", adapterOrdinal);
         break;
     case S_PRESENT_OCCLUDED:
         break;


### PR DESCRIPTION
Clean backport to jfx21u. This backport was already requested and approved in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8313648](https://bugs.openjdk.org/browse/JDK-8313648) needs maintainer approval

### Issue
 * [JDK-8313648](https://bugs.openjdk.org/browse/JDK-8313648): JavaFX application continues to show a black screen after graphic card driver crash (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx21u.git pull/37/head:pull/37` \
`$ git checkout pull/37`

Update a local copy of the PR: \
`$ git checkout pull/37` \
`$ git pull https://git.openjdk.org/jfx21u.git pull/37/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 37`

View PR using the GUI difftool: \
`$ git pr show -t 37`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx21u/pull/37.diff">https://git.openjdk.org/jfx21u/pull/37.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx21u/pull/37#issuecomment-1836119933)