### PR TITLE
8318714: Update copyright header for files modified in 2023

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -1,5 +1,5 @@
 ;
-; Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+; Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
 ; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 ;
 ; This code is free software; you can redistribute it and/or modify it

--- a/build.properties
+++ b/build.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/buildSrc/linux.gradle
+++ b/buildSrc/linux.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/buildSrc/src/main/groovy/com/sun/javafx/gradle/LinkTask.groovy
+++ b/buildSrc/src/main/groovy/com/sun/javafx/gradle/LinkTask.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/buildSrc/win.gradle
+++ b/buildSrc/win.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/gradle.properties.template
+++ b/gradle.properties.template
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.base/src/main/java/javafx/beans/Observable.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/Observable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.base/src/main/version-info/VersionInfo.java
+++ b/modules/javafx.base/src/main/version-info/VersionInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.base/src/shims/java/com/sun/javafx/binding/LazyObjectBindingStub.java
+++ b/modules/javafx.base/src/shims/java/com/sun/javafx/binding/LazyObjectBindingStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/native-decora/SSEBoxBlurPeer.cc
+++ b/modules/javafx.graphics/src/main/native-decora/SSEBoxBlurPeer.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/native-decora/SSEBoxShadowPeer.cc
+++ b/modules/javafx.graphics/src/main/native-decora/SSEBoxShadowPeer.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/native-decora/SSELinearConvolvePeer.cc
+++ b/modules/javafx.graphics/src/main/native-decora/SSELinearConvolvePeer.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/native-decora/SSELinearConvolveShadowPeer.cc
+++ b/modules/javafx.graphics/src/main/native-decora/SSELinearConvolveShadowPeer.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/native-decora/SSEUtils.cc
+++ b/modules/javafx.graphics/src/main/native-decora/SSEUtils.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/native-decora/SSEUtils.h
+++ b/modules/javafx.graphics/src/main/native-decora/SSEUtils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/native-glass/gtk/GlassTimer.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/GlassTimer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_window_ime.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_window_ime.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/native-glass/ios/GlassMacros.h
+++ b/modules/javafx.graphics/src/main/native-glass/ios/GlassMacros.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/native-glass/ios/GlassPasteboard.m
+++ b/modules/javafx.graphics/src/main/native-glass/ios/GlassPasteboard.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassMacros.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassMacros.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/native-prism-sw/JPiscesRenderer.c
+++ b/modules/javafx.graphics/src/main/native-prism-sw/JPiscesRenderer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/main/java/com/sun/webkit/WebPage.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/WebPage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/java/JavaRef.h
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/java/JavaRef.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/java/MainThreadJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/java/MainThreadJava.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/main/native/Source/WebCore/SourcesJava.txt
+++ b/modules/javafx.web/src/main/native/Source/WebCore/SourcesJava.txt
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+// Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/BufferImageJava.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/BufferImageJava.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/FontPlatformDataJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/FontPlatformDataJava.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/MediaPlayerPrivateJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/MediaPlayerPrivateJava.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/texmap/TextureMapperJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/texmap/TextureMapperJava.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/texmap/TextureMapperJava.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/texmap/TextureMapperJava.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/java/DragImageJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/java/DragImageJava.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/java/KeyboardEventJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/java/KeyboardEventJava.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/java/LoggingJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/java/LoggingJava.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/java/MouseEventJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/java/MouseEventJava.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/java/SharedBufferJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/java/SharedBufferJava.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/java/WheelEventJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/java/WheelEventJava.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/network/java/ResourceError.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/network/java/ResourceError.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/network/java/ResourceRequestJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/network/java/ResourceRequestJava.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/main/native/Tools/DumpRenderTree/java/TestRunnerJava.cpp
+++ b/modules/javafx.web/src/main/native/Tools/DumpRenderTree/java/TestRunnerJava.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/LoadTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/LoadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Update Copyright year in files modified in year 2023.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8318714](https://bugs.openjdk.org/browse/JDK-8318714) needs maintainer approval

### Issue
 * [JDK-8318714](https://bugs.openjdk.org/browse/JDK-8318714): Update copyright header for files modified in 2023 (**Task** - P2 - Approved)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx21u.git pull/38/head:pull/38` \
`$ git checkout pull/38`

Update a local copy of the PR: \
`$ git checkout pull/38` \
`$ git pull https://git.openjdk.org/jfx21u.git pull/38/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 38`

View PR using the GUI difftool: \
`$ git pr show -t 38`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx21u/pull/38.diff">https://git.openjdk.org/jfx21u/pull/38.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx21u/pull/38#issuecomment-1837936165)