### PR TITLE
8323221: Create release notes for JavaFX 21.0.2

### DIFF
--- a/doc-files/release-notes-21.0.2.md
+++ b/doc-files/release-notes-21.0.2.md
@@ -24,3 +24,11 @@ Issue key|Summary|Subcomponent
 [JDK-8315958](https://bugs.openjdk.org/browse/JDK-8315958)|Missing range checks in GlassPasteboard|window-toolkit
 [JDK-8319066](https://bugs.openjdk.org/browse/JDK-8319066)|Application window not always activated in macOS 14 Sonoma|window-toolkit
 [JDK-8319669](https://bugs.openjdk.org/browse/JDK-8319669)|[macos14] Running any JavaFX app prints Secure coding warning|window-toolkit
+
+## List of Security fixes
+
+Issue key|Summary|Subcomponent
+---------|-------|------------
+JDK-8313048 (not public)|Better Glyph handling|graphics
+JDK-8313105 (not public)|Improved media framing|media
+JDK-8313056 (not public)|General enhancements of Glass|window-toolkit

--- a/doc-files/release-notes-21.0.2.md
+++ b/doc-files/release-notes-21.0.2.md
@@ -1,0 +1,26 @@
+# Release Notes for JavaFX 21.0.2
+
+## Introduction
+
+The following notes describe important changes and information about this release. In some cases, the descriptions provide links to additional detailed information about an issue or a change.
+
+These notes document the JavaFX 21.0.2 update release. As such, they complement the [JavaFX 21](https://github.com/openjdk/jfx21u/blob/master/doc-files/release-notes-21.md) and [JavaFX 21.0.1](https://github.com/openjdk/jfx21u/blob/master/doc-files/release-notes-21.0.1.md) release notes.
+
+## List of Fixed Bugs
+
+Issue key|Summary|Subcomponent
+---------|-------|------------
+[JDK-8317370](https://bugs.openjdk.org/browse/JDK-8317370)|JavaFX runtime version is wrong at runtime|base
+[JDK-8311185](https://bugs.openjdk.org/browse/JDK-8311185)|VirtualFlow jump when cellcount changes|controls
+[JDK-8307536](https://bugs.openjdk.org/browse/JDK-8307536)|FileAlreadyExistsException from NativeLibLoader when running concurrent applications with empty cache|graphics
+[JDK-8313648](https://bugs.openjdk.org/browse/JDK-8313648)|JavaFX application continues to show a black screen after graphic card driver crash|graphics
+[JDK-8319079](https://bugs.openjdk.org/browse/JDK-8319079)|Missing range checks in decora|graphics
+[JDK-8317508](https://bugs.openjdk.org/browse/JDK-8317508)|Provide media support for libavcodec version 60|media
+[JDK-8318386](https://bugs.openjdk.org/browse/JDK-8318386)|Update Glib to 2.78.1|media
+[JDK-8318387](https://bugs.openjdk.org/browse/JDK-8318387)|Update GStreamer to 1.22.6|media
+[JDK-8320267](https://bugs.openjdk.org/browse/JDK-8320267)|WebView crashes on macOS 11 with WebKit 616.1|web
+[JDK-8251240](https://bugs.openjdk.org/browse/JDK-8251240)|Menus inaccessible on Linux with i3 wm|window-toolkit
+[JDK-8315074](https://bugs.openjdk.org/browse/JDK-8315074)|Possible null pointer access in native glass|window-toolkit
+[JDK-8315958](https://bugs.openjdk.org/browse/JDK-8315958)|Missing range checks in GlassPasteboard|window-toolkit
+[JDK-8319066](https://bugs.openjdk.org/browse/JDK-8319066)|Application window not always activated in macOS 14 Sonoma|window-toolkit
+[JDK-8319669](https://bugs.openjdk.org/browse/JDK-8319669)|[macos14] Running any JavaFX app prints Secure coding warning|window-toolkit


### PR DESCRIPTION
Release notes for JavaFX 21.0.2.

Notes to reviewers:

I used the following filter to pick the issues:

https://bugs.openjdk.org/issues/?filter=45268

The original filter, with the backport IDs, is here:

https://bugs.openjdk.org/issues/?filter=45267

As usual, I excluded test bugs, cleanup bugs, etc.

NOTE: Once the CPU release ships on 2023-01-16 (tomorrow), I will add any security bugs and make this PR `rfr`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8323221](https://bugs.openjdk.org/browse/JDK-8323221) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323221](https://bugs.openjdk.org/browse/JDK-8323221): Create release notes for JavaFX 21.0.2 (**Task** - P2 - Approved)


### Reviewers
 * @abhinayagarwal (no known openjdk.org user name / role)
 * [Johan Vos](https://openjdk.org/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx21u.git pull/39/head:pull/39` \
`$ git checkout pull/39`

Update a local copy of the PR: \
`$ git checkout pull/39` \
`$ git pull https://git.openjdk.org/jfx21u.git pull/39/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 39`

View PR using the GUI difftool: \
`$ git pr show -t 39`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx21u/pull/39.diff">https://git.openjdk.org/jfx21u/pull/39.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx21u/pull/39#issuecomment-1894194404)