### PR TITLE
8321970: New table columns don't appear when using fixed cell size unless refreshing tableView

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableRowSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableRowSkinBase.java
@@ -539,7 +539,8 @@ public abstract class TableRowSkinBase<T,
                 }
             }
             getChildren().removeAll(toRemove);
-        } else if (resetChildren || cellsEmpty) {
+        }
+        if (resetChildren || cellsEmpty) {
             getChildren().setAll(cells);
         }
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TableRowSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TableRowSkinTest.java
@@ -26,6 +26,7 @@
 package test.javafx.scene.control.skin;
 
 import com.sun.javafx.tk.Toolkit;
+import javafx.beans.property.SimpleStringProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.geometry.Insets;
@@ -314,6 +315,27 @@ public class TableRowSkinTest {
     @Test
     public void invisibleColumnsShouldRemoveCorrespondingCellsInRow() {
         invisibleColumnsShouldRemoveCorrespondingCellsInRowImpl();
+    }
+
+    /**
+     * The {@link TableRowSkin} should add new cells after new columns are added.
+     * See: JDK-8321970
+     */
+    @Test
+    public void cellsShouldBeAddedInRowFixedCellSize() {
+        tableView.setFixedCellSize(24);
+
+        TableColumn<Person, String> otherColumn = new TableColumn<>("other");
+        otherColumn.setPrefWidth(100);
+        otherColumn.setCellValueFactory(value -> new SimpleStringProperty("other"));
+        tableView.getColumns().add(otherColumn);
+
+        Toolkit.getToolkit().firePulse();
+        assertEquals(5, tableView.getColumns().size());
+
+        Toolkit.getToolkit().firePulse();
+        IndexedCell<?> row = VirtualFlowTestUtils.getCell(tableView, 1);
+        assertEquals(5, row.getChildrenUnmodifiable().stream().filter(TableCell.class::isInstance).count());
     }
 
     @After


### PR DESCRIPTION
Hi all,

This pull request contains a clean backport of commit [ab68b716](https://github.com/openjdk/jfx/commit/ab68b716fbfd807918ca4a1bc096dcf40d9cfcbd) from the [openjdk/jfx](https://git.openjdk.org/jfx) repository.

The commit being backported was authored by Jose Pereda on 21 Dec 2023 and was reviewed by Andy Goryachev.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8321970](https://bugs.openjdk.org/browse/JDK-8321970) needs maintainer approval

### Issue
 * [JDK-8321970](https://bugs.openjdk.org/browse/JDK-8321970): New table columns don't appear when using fixed cell size unless refreshing tableView (**Bug** - P4 - Approved)


### Reviewers
 * [Johan Vos](https://openjdk.org/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx21u.git pull/44/head:pull/44` \
`$ git checkout pull/44`

Update a local copy of the PR: \
`$ git checkout pull/44` \
`$ git pull https://git.openjdk.org/jfx21u.git pull/44/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 44`

View PR using the GUI difftool: \
`$ git pr show -t 44`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx21u/pull/44.diff">https://git.openjdk.org/jfx21u/pull/44.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx21u/pull/44#issuecomment-1959195211)