### PR TITLE
8326989: Text selection issues on WebView after WebKit 617.1

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/editing/FrameSelection.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/editing/FrameSelection.cpp
@@ -480,8 +480,12 @@ void FrameSelection::setSelection(const VisibleSelection& selection, OptionSet<S
     if (frameView && frameView->layoutContext().isLayoutPending())
         return;
 
-    if (!(options & SetSelectionOption::IsUserTriggered))
+    if (!(options & SetSelectionOption::IsUserTriggered)) {
+#if PLATFORM(JAVA)
+        updateSelectionAppearanceNow();
+#endif
         return;
+    }
 
     updateAndRevealSelection(intent, options.contains(SetSelectionOption::SmoothScroll) ? ScrollBehavior::Smooth : ScrollBehavior::Instant,
         options.contains(SetSelectionOption::RevealSelectionBounds) ? RevealExtentOption::DoNotRevealExtent : RevealExtentOption::RevealExtent,


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit 64af9875 from the openjdk/jfx repository.

The commit being backported was authored by Hima Bindu Meda on 7 Mar 2024 and was reviewed by Kevin Rushforth and Jose Pereda.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8326989](https://bugs.openjdk.org/browse/JDK-8326989) needs maintainer approval

### Issue
 * [JDK-8326989](https://bugs.openjdk.org/browse/JDK-8326989): Text selection issues on WebView after WebKit 617.1 (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx21u.git pull/53/head:pull/53` \
`$ git checkout pull/53`

Update a local copy of the PR: \
`$ git checkout pull/53` \
`$ git pull https://git.openjdk.org/jfx21u.git pull/53/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 53`

View PR using the GUI difftool: \
`$ git pr show -t 53`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx21u/pull/53.diff">https://git.openjdk.org/jfx21u/pull/53.diff</a>

</details>
