### PR TITLE
8322795: CSS performance regression up to 10x

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/css/SimpleSelector.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/SimpleSelector.java
@@ -97,6 +97,7 @@ final public class SimpleSelector extends Selector {
      * styleClasses converted to a set of bit masks
      */
     private final Set<StyleClass> styleClassSet;
+    private final Set<StyleClass> unwrappedStyleClassSet;
 
     private final String id;
 
@@ -146,7 +147,7 @@ final public class SimpleSelector extends Selector {
         // then match needs to check name
         this.matchOnName = (name != null && !("".equals(name)) && !("*".equals(name)));
 
-        Set<StyleClass> scs = new StyleClassSet();
+        this.unwrappedStyleClassSet = new StyleClassSet();
 
         if (styleClasses != null) {
             for (int n = 0; n < styleClasses.size(); n++) {
@@ -154,11 +155,11 @@ final public class SimpleSelector extends Selector {
                 final String styleClassName = styleClasses.get(n);
                 if (styleClassName == null || styleClassName.isEmpty()) continue;
 
-                scs.add(StyleClassSet.getStyleClass(styleClassName));
+                unwrappedStyleClassSet.add(StyleClassSet.getStyleClass(styleClassName));
             }
         }
 
-        this.styleClassSet = Collections.unmodifiableSet(scs);
+        this.styleClassSet = Collections.unmodifiableSet(unwrappedStyleClassSet);
         this.matchOnStyleClass = (this.styleClassSet.size() > 0);
 
         PseudoClassState pcs = new PseudoClassState();
@@ -287,7 +288,8 @@ final public class SimpleSelector extends Selector {
     // This selector matches when class="pastoral blue aqua marine" but does not
     // match for class="pastoral blue".
     private boolean matchStyleClasses(StyleClassSet otherStyleClasses) {
-        return otherStyleClasses.containsAll(styleClassSet);
+        // checks against unwrapped version so BitSet can do its special casing for performance
+        return otherStyleClasses.containsAll(unwrappedStyleClassSet);
     }
 
     @Override public boolean equals(Object obj) {


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8322795](https://bugs.openjdk.org/browse/JDK-8322795) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322795](https://bugs.openjdk.org/browse/JDK-8322795): CSS performance regression up to 10x (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx21u.git pull/54/head:pull/54` \
`$ git checkout pull/54`

Update a local copy of the PR: \
`$ git checkout pull/54` \
`$ git pull https://git.openjdk.org/jfx21u.git pull/54/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 54`

View PR using the GUI difftool: \
`$ git pr show -t 54`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx21u/pull/54.diff">https://git.openjdk.org/jfx21u/pull/54.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx21u/pull/54#issuecomment-1991177513)