### PR TITLE
8330462: StringIndexOutOfBoundException when typing anything into TextField

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinTextRangeProvider.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinTextRangeProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,8 @@ package com.sun.glass.ui.win;
 
 import static javafx.scene.AccessibleAttribute.*;
 import java.text.BreakIterator;
+
+import com.sun.javafx.util.Utils;
 import javafx.geometry.Bounds;
 import javafx.scene.AccessibleAction;
 import javafx.scene.AccessibleAttribute;
@@ -98,8 +100,26 @@ class WinTextRangeProvider {
         }
 
         int length = text.length();
-        start = Math.max(0, Math.min(start, length));
-        end = Math.max(start, Math.min(end, length));
+        start = Utils.clamp(0, start, length);
+        end = Utils.clamp(start, end, length);
+    }
+
+    /**
+     * In the context of substrings, this method calculates the end index based on the start index,
+     * requested string length, and the maximum end index. <code>0 <= start <= end <= length</code>;
+     * see {@link #validateRange(String)}.
+     *
+     * @param startIndex The start index in a string. Needs to be 0 or more (not checked in the code).
+     * @param length The requested length of a string when starting from "start".
+     *               Negative numbers are treated as full length.
+     * @param endIndex The maximum end index to return. Needs to be equal or greater than startIndex
+     *                    (not checked in the code).
+     */
+    static int getEndIndex(int startIndex, int length, int endIndex) {
+        if (length < 0 || (endIndex - startIndex) <= length) {
+            return endIndex;
+        }
+        return startIndex + length;
     }
 
     void setRange(int start, int end) {
@@ -358,11 +378,16 @@ class WinTextRangeProvider {
         return accessible.getNativeAccessible();
     }
 
+    /**
+     * Returns the text contained in the TEXT attribute, starting from the start index and ending at the end index.
+     *
+     * @param maxLength The maximum length of the returned string
+     */
     private String GetText(int maxLength) {
         String text = (String)getAttribute(TEXT);
         if (text == null) return null;
         validateRange(text);
-        int endOffset = maxLength != -1 ? Math.min(end, start + maxLength) : end;
+        int endOffset = getEndIndex(start, maxLength, end);
 //        System.out.println("+GetText [" + text.substring(start, endOffset)+"]");
         return text.substring(start, endOffset);
     }

--- a/modules/javafx.graphics/src/shims/java/com/sun/glass/ui/win/WinTextRangeProviderShim.java
+++ b/modules/javafx.graphics/src/shims/java/com/sun/glass/ui/win/WinTextRangeProviderShim.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.sun.glass.ui.win;
+
+/**
+ * Provides access to the {@link WinTextRangeProvider} class by making its
+ * package-private fields and methods public for test cases in
+ * {@link test.com.sun.glass.ui.win.WinTextRangeProviderTest WinTextRangeProviderTest}.
+ */
+public class WinTextRangeProviderShim {
+    public static int getEndIndex(int start, int length, int maxEndIndex) {
+        return WinTextRangeProvider.getEndIndex(start, length, maxEndIndex);
+    }
+}

--- a/tests/system/src/test/.classpath
+++ b/tests/system/src/test/.classpath
@@ -14,7 +14,7 @@
 	<classpathentry combineaccessrules="false" kind="src" path="/graphics">
 		<attributes>
 			<attribute name="module" value="true"/>
-			<attribute name="add-exports" value="javafx.graphics/com.sun.glass.ui=ALL-UNNAMED:javafx.graphics/com.sun.glass.ui.monocle=ALL-UNNAMED:javafx.graphics/com.sun.javafx.sg.prism=ALL-UNNAMED:javafx.graphics/com.sun.prism.impl=ALL-UNNAMED:javafx.graphics/com.sun.javafx.image.impl=ALL-UNNAMED:javafx.graphics/com.sun.glass.events=ALL-UNNAMED:javafx.graphics/com.sun.javafx.application=ALL-UNNAMED:javafx.graphics/com.sun.javafx.css=ALL-UNNAMED:javafx.graphics/com.sun.javafx.geom=ALL-UNNAMED:javafx.graphics/com.sun.javafx.tk=ALL-UNNAMED:javafx.graphics/com.sun.glass.ui.mac=ALL-UNNAMED"/>
+			<attribute name="add-exports" value="javafx.graphics/com.sun.glass.ui=ALL-UNNAMED:javafx.graphics/com.sun.glass.ui.monocle=ALL-UNNAMED:javafx.graphics/com.sun.javafx.sg.prism=ALL-UNNAMED:javafx.graphics/com.sun.prism.impl=ALL-UNNAMED:javafx.graphics/com.sun.javafx.image.impl=ALL-UNNAMED:javafx.graphics/com.sun.glass.events=ALL-UNNAMED:javafx.graphics/com.sun.javafx.application=ALL-UNNAMED:javafx.graphics/com.sun.javafx.css=ALL-UNNAMED:javafx.graphics/com.sun.javafx.geom=ALL-UNNAMED:javafx.graphics/com.sun.javafx.tk=ALL-UNNAMED:javafx.graphics/com.sun.glass.ui.mac=ALL-UNNAMED:javafx.graphics/com.sun.glass.ui.win=ALL-UNNAMED"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry combineaccessrules="false" kind="src" path="/controls">

--- a/tests/system/src/test/addExports
+++ b/tests/system/src/test/addExports
@@ -6,6 +6,7 @@
 --add-exports javafx.graphics/com.sun.glass.ui=ALL-UNNAMED
 --add-exports javafx.graphics/com.sun.glass.ui.mac=ALL-UNNAMED
 --add-exports javafx.graphics/com.sun.glass.ui.monocle=ALL-UNNAMED
+--add-exports javafx.graphics/com.sun.glass.ui.win=ALL-UNNAMED
 --add-exports javafx.graphics/com.sun.javafx.animation=ALL-UNNAMED
 --add-exports javafx.graphics/com.sun.javafx.application=ALL-UNNAMED
 --add-exports javafx.graphics/com.sun.javafx.css=ALL-UNNAMED

--- a/tests/system/src/test/java/test/com/sun/glass/ui/win/WinTextRangeProviderTest.java
+++ b/tests/system/src/test/java/test/com/sun/glass/ui/win/WinTextRangeProviderTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package test.com.sun.glass.ui.win;
+
+import com.sun.javafx.PlatformUtil;
+import com.sun.glass.ui.win.WinTextRangeProviderShim;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.stream.Stream;
+
+import test.util.Util;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class WinTextRangeProviderTest {
+
+    private static final CountDownLatch startupLatch = new CountDownLatch(1);
+
+    @BeforeAll
+    static void initFX() throws Exception {
+        assumeTrue(PlatformUtil.isWindows());
+        Util.startup(startupLatch, () -> startupLatch.countDown());
+    }
+
+    @AfterAll
+    static void shutdown() {
+        assumeTrue(PlatformUtil.isWindows());
+        Util.shutdown();
+    }
+
+    static Stream<Arguments> getEndIndexParameters() {
+        return Stream.of(
+                Arguments.of(1, 0, 1, 2),
+                Arguments.of(1, 0, 2, 1),
+                Arguments.of(55, 50, 10, 55),
+                Arguments.of(60, 50, 10, Integer.MAX_VALUE),
+                Arguments.of(1, 0, Integer.MAX_VALUE, 1),
+                Arguments.of(50, 50, Integer.MAX_VALUE, 50),
+                Arguments.of(Integer.MAX_VALUE, 0, Integer.MAX_VALUE, Integer.MAX_VALUE),
+                Arguments.of(60, 50, -1, 60),
+                Arguments.of(60, 50, Integer.MIN_VALUE, 60)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("getEndIndexParameters")
+    public void testGetEndIndex(Integer expected, Integer startIndex, Integer length, Integer maxEndIndex) {
+        assumeTrue(PlatformUtil.isWindows());
+        assertEquals(expected, WinTextRangeProviderShim.getEndIndex(startIndex, length, maxEndIndex));
+    }
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [d3da033a](https://github.com/openjdk/jfx/commit/d3da033a2dd5c287733545935242a8d1f71c0554) from the [openjdk/jfx](https://git.openjdk.org/jfx) repository.

The commit being backported was authored by Oliver Kopp on 8 May 2024 and was reviewed by Andy Goryachev, Kevin Rushforth and Ambarish Rapte.

The backport is almost clean: While cherry picking the mainline commit, a minor merge conflict was shown at the file `tests/system/src/test/.classpath`: The mainline file has a few additional exports compared to 21u, which are not needed here.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8330462](https://bugs.openjdk.org/browse/JDK-8330462) needs maintainer approval

### Issue
 * [JDK-8330462](https://bugs.openjdk.org/browse/JDK-8330462): StringIndexOutOfBoundException when typing anything into TextField (**Bug** - P2 - Approved)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx21u.git pull/57/head:pull/57` \
`$ git checkout pull/57`

Update a local copy of the PR: \
`$ git checkout pull/57` \
`$ git pull https://git.openjdk.org/jfx21u.git pull/57/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 57`

View PR using the GUI difftool: \
`$ git pr show -t 57`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx21u/pull/57.diff">https://git.openjdk.org/jfx21u/pull/57.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx21u/pull/57#issuecomment-2112974231)