### PR TITLE
8334874: Horizontal scroll events from touch pads should scroll the TabPane tabs

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TabPaneSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TabPaneSkin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -934,17 +934,23 @@ public class TabPaneSkin extends SkinBase<TabPane> {
             // Scrolling the mouse wheel downwards results in the tabs scrolling left (i.e. exposing the right-most tabs)
             // Scrolling the mouse wheel upwards results in the tabs scrolling right (i.e. exposing th left-most tabs)
             addEventHandler(ScrollEvent.SCROLL, (ScrollEvent e) -> {
+                double dx = e.getDeltaX();
+                double dy = e.getDeltaY();
+
                 Side side = getSkinnable().getSide();
                 side = side == null ? Side.TOP : side;
                 switch (side) {
                     default:
                     case TOP:
                     case BOTTOM:
-                        setScrollOffset(scrollOffset + e.getDeltaY());
+                        // Consider vertical scroll events (dy > dx) from mouse wheel and trackpad,
+                        // and horizontal scroll events from a trackpad (dx > dy)
+                        dx = Math.abs(dy) > Math.abs(dx) ? dy : dx;
+                        setScrollOffset(scrollOffset + dx);
                         break;
                     case LEFT:
                     case RIGHT:
-                        setScrollOffset(scrollOffset - e.getDeltaY());
+                        setScrollOffset(scrollOffset - dy);
                         break;
                 }
 


### PR DESCRIPTION
Almost clean backport of JDK-8334874: Horizontal scroll events from touch pads should scroll the TabPane tabs
The only change was the (c) date that had changed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8334874](https://bugs.openjdk.org/browse/JDK-8334874) needs maintainer approval

### Issue
 * [JDK-8334874](https://bugs.openjdk.org/browse/JDK-8334874): Horizontal scroll events from touch pads should scroll the TabPane tabs (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx21u.git pull/64/head:pull/64` \
`$ git checkout pull/64`

Update a local copy of the PR: \
`$ git checkout pull/64` \
`$ git pull https://git.openjdk.org/jfx21u.git pull/64/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 64`

View PR using the GUI difftool: \
`$ git pr show -t 64`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx21u/pull/64.diff">https://git.openjdk.org/jfx21u/pull/64.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx21u/pull/64#issuecomment-2262440253)