### PR TITLE
8318841: macOS: Memory leak with MenuItem when Menu.useSystemMenuBar(true) is used

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacMenuBarDelegate.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacMenuBarDelegate.java
@@ -49,10 +49,12 @@ class MacMenuBarDelegate implements MenuBarDelegate {
     @Override public boolean remove(MenuDelegate menu, int pos) {
         MacMenuDelegate macMenu = (MacMenuDelegate)menu;
         _remove(ptr, macMenu.ptr, pos);
+        macMenu.ptr = 0;
         return true;
     }
 
     @Override public long getNativeMenu() {
         return ptr;
     }
+
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacMenuDelegate.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacMenuDelegate.java
@@ -69,6 +69,7 @@ class MacMenuDelegate implements MenuDelegate, MenuItemDelegate {
 
     private native void _insert(long menuPtr, long submenuPtr, int pos);
     @Override public boolean insert(MenuDelegate menu, int pos) {
+        if (ptr == 0) return false;
         MacMenuDelegate macMenu = (MacMenuDelegate)menu;
         _insert(ptr, macMenu.ptr, pos);
         return true;
@@ -76,6 +77,7 @@ class MacMenuDelegate implements MenuDelegate, MenuItemDelegate {
 
     @Override public boolean insert(MenuItemDelegate item, int pos) {
         MacMenuDelegate macMenu = (MacMenuDelegate)item;
+        if (ptr == 0) return false;
         _insert(ptr, macMenu != null ? macMenu.ptr : 0, pos);
         return true;
     }
@@ -83,36 +85,46 @@ class MacMenuDelegate implements MenuDelegate, MenuItemDelegate {
     private native void _remove(long menuPtr, long submenuPtr, int pos);
     @Override public boolean remove(MenuDelegate menu, int pos) {
         MacMenuDelegate macMenu = (MacMenuDelegate)menu;
+        if (ptr == 0) return false;
         _remove(ptr, macMenu.ptr, pos);
+        macMenu.ptr = 0;
         return true;
     }
 
     @Override public boolean remove(MenuItemDelegate item, int pos) {
         MacMenuDelegate macMenu = (MacMenuDelegate)item;
+        if (ptr == 0) return false;
         _remove(ptr, macMenu == null ? 0L : macMenu.ptr, pos);
+        if (macMenu != null) {
+            macMenu.ptr = 0L;
+        }
         return true;
     }
 
     private native void _setTitle(long menuPtr, String title);
     @Override public boolean setTitle(String title) {
+        if (ptr == 0) return false;
         _setTitle(ptr, title);
         return true;
     }
 
     private native void _setShortcut(long menuPtr, char shortcut, int modifiers);
     @Override public boolean setShortcut(int shortcutKey, int shortcutModifiers) {
+        if (ptr == 0) return false;
         _setShortcut(ptr, (char)shortcutKey, shortcutModifiers);
         return true;
     }
 
     private native void _setPixels(long menuPtr, Pixels pixels);
     @Override public boolean setPixels(Pixels pixels) {
+        if (ptr == 0) return false;
         _setPixels(ptr, pixels);
         return true;
     }
 
     private native void _setEnabled(long menuPtr, boolean enabled);
     @Override public boolean setEnabled(boolean enabled) {
+        if (ptr == 0) return false;
         _setEnabled(ptr, enabled);
         return true;
     }

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassMenu.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassMenu.m
@@ -371,6 +371,7 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_mac_MacMenuBarDelegate__1remove
         GlassMenu *glassmenu = (GlassMenu *)jlong_to_ptr(jMenuPtr);
         if ([menubar->menu indexOfItem: glassmenu->item] != -1) {
             [menubar->menu removeItem:glassmenu->item];
+            [glassmenu release];
         }
         [[NSApp mainMenu] update];
     }
@@ -533,6 +534,7 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_mac_MacMenuDelegate__1remove
 
             if ([menu->menu indexOfItem: submenu->item] != -1) {
                 [menu->menu removeItem:submenu->item];
+                [submenu release];
             }
         }
         else

--- a/tests/system/src/test/java/test/javafx/stage/SystemMenuBarTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/SystemMenuBarTest.java
@@ -29,6 +29,9 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import test.util.Util;
+import test.util.memory.JMemoryBuddy;
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -42,6 +45,7 @@ import javafx.stage.Stage;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SystemMenuBarTest {
     @BeforeClass
@@ -60,6 +64,7 @@ public class SystemMenuBarTest {
     }
 
     CountDownLatch menubarLatch = new CountDownLatch(1);
+    CountDownLatch memoryLatch = new CountDownLatch(1);
     AtomicBoolean failed = new AtomicBoolean(false);
 
     @Test
@@ -109,4 +114,63 @@ public class SystemMenuBarTest {
 
         return menuBar;
     }
+
+    @Test
+    public void testMemoryLeak() throws InterruptedException {
+        Util.runAndWait(() -> {
+            Thread.currentThread().setUncaughtExceptionHandler((t,e) -> {
+                e.printStackTrace();
+                failed.set(true);
+                memoryLatch.countDown();
+            });
+            createMenuBarWithItemsStage();
+        });
+        memoryLatch.await();
+        assertFalse(failed.get());
+    }
+
+    private void createMenuBarWithItemsStage() {
+        final ArrayList<WeakReference<MenuItem>> uncollectedMenuItems = new ArrayList<>();
+
+        Stage stage = new Stage();
+        VBox root = new VBox();
+        final MenuBar menuBar = new MenuBar();
+        final Menu menu = new Menu("MyMenu");
+        menuBar.getMenus().add(menu);
+        menuBar.setUseSystemMenuBar(true);
+        root.getChildren().add(menuBar);
+
+        Scene scene = new Scene(root);
+        stage.setScene(scene);
+        stage.show();
+        stage.requestFocus();
+        Thread t = new Thread() {
+            @Override public void run() {
+                for (int i = 0; i < 10; i++) {
+                    try {
+                        Thread.sleep(20);
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                    Platform.runLater(() -> {
+                        menu.getItems().clear();
+                        MenuItem menuItem = new MenuItem("MyItem");
+                        WeakReference<MenuItem> wr = new WeakReference<>(menuItem);
+                        uncollectedMenuItems.add(wr);
+                        menu.getItems().add(menuItem);
+                    });
+                }
+                Platform.runLater( () -> {
+                    int strongCount = 0;
+                    for (WeakReference<MenuItem> wr: uncollectedMenuItems) {
+                        if (!JMemoryBuddy.checkCollectable(wr)) strongCount++;
+                    }
+                    assertEquals(1, strongCount, "Only the last menuItem should be alive");
+                    memoryLatch.countDown();
+                });
+            }
+        };
+        t.start();
+    }
+
 }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8318841](https://bugs.openjdk.org/browse/JDK-8318841) needs maintainer approval

### Issue
 * [JDK-8318841](https://bugs.openjdk.org/browse/JDK-8318841): macOS: Memory leak with MenuItem when Menu.useSystemMenuBar(true) is used (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx21u.git pull/65/head:pull/65` \
`$ git checkout pull/65`

Update a local copy of the PR: \
`$ git checkout pull/65` \
`$ git pull https://git.openjdk.org/jfx21u.git pull/65/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 65`

View PR using the GUI difftool: \
`$ git pr show -t 65`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx21u/pull/65.diff">https://git.openjdk.org/jfx21u/pull/65.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx21u/pull/65#issuecomment-2262588766)