### PR TITLE
8334657: Enable binary check

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -31,6 +31,7 @@ tags=(jdk-){0,1}([1-9]([0-9]*)(\.(0|[1-9][0-9]*)){0,3})(\+(([0-9]+))|(-ga))|[1-9
 
 [checks]
 error=author,reviewers,merge,message,issues,whitespace,executable
+warning=issuestitle,binary
 
 [census]
 version=0


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit 101e5175 from the openjdk/jfx repository.

The commit being backported was authored by Kevin Rushforth on 25 Jun 2024 and was reviewed by Ambarish Rapte and Phil Race.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8334657](https://bugs.openjdk.org/browse/JDK-8334657) needs maintainer approval
- [x] [JDK-8334656](https://bugs.openjdk.org/browse/JDK-8334656) needs maintainer approval

### Issues
 * [JDK-8334657](https://bugs.openjdk.org/browse/JDK-8334657): Enable binary check (**Bug** - P3 - Approved)
 * [JDK-8334656](https://bugs.openjdk.org/browse/JDK-8334656): Enable issuestitle check (**Bug** - P4 - Approved)


### Reviewers
 * [Jose Pereda](https://openjdk.org/census#jpereda) (@jperedadnr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx21u.git pull/68/head:pull/68` \
`$ git checkout pull/68`

Update a local copy of the PR: \
`$ git checkout pull/68` \
`$ git pull https://git.openjdk.org/jfx21u.git pull/68/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 68`

View PR using the GUI difftool: \
`$ git pr show -t 68`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx21u/pull/68.diff">https://git.openjdk.org/jfx21u/pull/68.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx21u/pull/68#issuecomment-2295386562)