### PR TITLE
8334713: WebKit build failed on LoongArch64 because currentStackPointer is undefined

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/StackPointer.cpp
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/StackPointer.cpp
@@ -136,6 +136,17 @@ asm (
      ".previous" "\n"
 );
 
+#elif CPU(LOONGARCH64) && COMPILER(GCC_COMPATIBLE)
+asm (
+    ".text" "\n"
+    ".globl " SYMBOL_STRING(currentStackPointer) "\n"
+    SYMBOL_STRING(currentStackPointer) ":" "\n"
+
+     "move $r4, $r3" "\n"
+     "jr   $r1" "\n"
+     ".previous" "\n"
+);
+
 #else
 #error "Unsupported platform: need implementation of currentStackPointer."
 #endif


### PR DESCRIPTION
Hi all,

Please review the clean backport of the commit [ca04c87d](https://github.com/openjdk/jfx/commit/ca04c87d307c36591162af8cd6298ede17812834) from the [openjdk/jfx](https://git.openjdk.org/jfx) repository.

The commit being backported was authored by @theaoqi on 27 Jun 2024 and was reviewed by @kevinrushforth and @HimaBinduMeda. This is part of the prerequisites for backporting WebKit 619.1 to OpenJFX 21.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8334713](https://bugs.openjdk.org/browse/JDK-8334713) needs maintainer approval

### Issue
 * [JDK-8334713](https://bugs.openjdk.org/browse/JDK-8334713): WebKit build failed on LoongArch64 because currentStackPointer is undefined (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx21u.git pull/69/head:pull/69` \
`$ git checkout pull/69`

Update a local copy of the PR: \
`$ git checkout pull/69` \
`$ git pull https://git.openjdk.org/jfx21u.git pull/69/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 69`

View PR using the GUI difftool: \
`$ git pr show -t 69`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx21u/pull/69.diff">https://git.openjdk.org/jfx21u/pull/69.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx21u/pull/69#issuecomment-2340615632)