### PR TITLE
8331765: Websocket callbacks are not executed after WebKit 617.1 update

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/Headers.cmake
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Headers.cmake
@@ -621,6 +621,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/webdatabase/OriginLock.h
 
     Modules/websockets/ThreadableWebSocketChannel.h
+    Modules/websockets/WebSocketChannel.h
     Modules/websockets/WebSocketChannelClient.h
     Modules/websockets/WebSocketChannelInspector.h
     Modules/websockets/WebSocketDeflateFramer.h
@@ -2211,6 +2212,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/network/SameSiteInfo.h
     platform/network/ShouldRelaxThirdPartyCookieBlocking.h
     platform/network/SocketStreamError.h
+    platform/network/SocketStreamHandle.h
+    platform/network/SocketStreamHandleClient.h
     platform/network/StorageSessionProvider.h
     platform/network/StoredCredentialsPolicy.h
     platform/network/SynchronousLoaderClient.h

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.cpp
@@ -42,6 +42,9 @@
 #include "SocketProvider.h"
 #include "ThreadableWebSocketChannelClientWrapper.h"
 #include "UserContentProvider.h"
+#if PLATFORM(JAVA)
+#include "WebSocketChannel.h"
+#endif
 #include "WebSocketChannelClient.h"
 #include "WorkerGlobalScope.h"
 #include "WorkerRunLoop.h"
@@ -52,7 +55,10 @@ namespace WebCore {
 
 RefPtr<ThreadableWebSocketChannel> ThreadableWebSocketChannel::create(Document& document, WebSocketChannelClient& client, SocketProvider& provider)
 {
+#if !PLATFORM(JAVA)
     return provider.createWebSocketChannel(document, client);
+#endif
+    return WebSocketChannel::create(document, client, provider);
 }
 
 RefPtr<ThreadableWebSocketChannel> ThreadableWebSocketChannel::create(ScriptExecutionContext& context, WebSocketChannelClient& client, SocketProvider& provider)

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/websockets/WebSocket.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/websockets/WebSocket.cpp
@@ -278,14 +278,7 @@ ExceptionOr<void> WebSocket::connect(const String& url, const Vector<String>& pr
 
     if (auto* provider = context.socketProvider())
         m_channel = ThreadableWebSocketChannel::create(*scriptExecutionContext(), *this, *provider);
-#if PLATFORM(JAVA)
-    if (!m_channel) {
-        String message;
-        message = "WebSocket connection error invalid WebSocketChannel"_s;
-        context.addConsoleMessage(MessageSource::JS, MessageLevel::Error, message);
-        return {};
-    }
-#endif
+
     // Every ScriptExecutionContext should have a SocketProvider.
     RELEASE_ASSERT(m_channel);
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/websockets/WebSocketChannel.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/websockets/WebSocketChannel.cpp
@@ -1,0 +1,867 @@
+/*
+ * Copyright (C) 2011, 2012 Google Inc.  All rights reserved.
+ * Copyright (C) 2018-2021 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#if PLATFORM(JAVA)
+
+#include "config.h"
+#include "WebSocketChannel.h"
+
+#include "Blob.h"
+#include "CookieJar.h"
+#include "Document.h"
+#include "DocumentLoader.h"
+#include "ExceptionCode.h"
+#include "FileReaderLoader.h"
+#include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
+#include "FrameLoader.h"
+#include "InspectorInstrumentation.h"
+#include "Logging.h"
+#include "NetworkingContext.h"
+#include "Page.h"
+#include "ProgressTracker.h"
+#include "ResourceRequest.h"
+#include "ScriptExecutionContext.h"
+#include "SocketProvider.h"
+#include "SocketStreamError.h"
+#include "SocketStreamHandle.h"
+#include "UserContentProvider.h"
+#include "WebSocketChannelClient.h"
+#include "WebSocketHandshake.h"
+#include <JavaScriptCore/ArrayBuffer.h>
+#include <wtf/FastMalloc.h>
+#include <wtf/text/CString.h>
+
+namespace WebCore {
+
+const Seconds TCPMaximumSegmentLifetime { 2_min };
+
+WebSocketChannel::WebSocketChannel(Document& document, WebSocketChannelClient& client, SocketProvider& provider)
+    : m_document(document)
+    , m_client(client)
+    , m_resumeTimer(*this, &WebSocketChannel::resumeTimerFired)
+    , m_closingTimer(*this, &WebSocketChannel::closingTimerFired)
+    , m_progressIdentifier(WebSocketChannelIdentifier::generate())
+    , m_socketProvider(provider)
+{
+    LOG(Network, "WebSocketChannel %p ctor, progress identifier %" PRIu64, this, m_progressIdentifier.toUInt64());
+}
+
+WebSocketChannel::~WebSocketChannel()
+{
+    LOG(Network, "WebSocketChannel %p dtor", this);
+}
+
+WebSocketChannel::ConnectStatus WebSocketChannel::connect(const URL& requestedURL, const String& protocol)
+{
+    LOG(Network, "WebSocketChannel %p connect()", this);
+
+    auto validatedURL = validateURL(*m_document, requestedURL);
+    if (!validatedURL)
+        return ConnectStatus::KO;
+    ASSERT(!m_handle);
+    ASSERT(!m_suspended);
+
+    if (validatedURL->url != requestedURL && m_client)
+        m_client->didUpgradeURL();
+
+    m_allowCookies = validatedURL->areCookiesAllowed;
+    String userAgent = m_document->userAgent(m_document->url());
+    String clientOrigin = m_document->securityOrigin().toString();
+
+    bool isAppInitiated = true;
+    if (auto* documentLoader = m_document->loader())
+        isAppInitiated = documentLoader->lastNavigationWasAppInitiated();
+
+    m_handshake = makeUnique<WebSocketHandshake>(validatedURL->url, protocol, userAgent, clientOrigin, m_allowCookies, isAppInitiated);
+    m_handshake->reset();
+#if !PLATFORM(JAVA)
+        m_handshake->addExtensionProcessor(m_deflateFramer.createExtensionProcessor());
+#endif
+    if (m_progressIdentifier)
+        InspectorInstrumentation::didCreateWebSocket(m_document.get(), m_progressIdentifier, validatedURL->url);
+
+    auto* frame = m_document->frame();
+    auto* page = m_document->page();
+    if (!frame || !page)
+        return ConnectStatus::KO;
+
+    ref();
+    String partition = m_document->domainForCachePartition();
+    // m_handle = m_socketProvider->createSocketStreamHandle(m_handshake->url(), *this, identifier(), page->sessionID(), partition, frame->loader().networkingContext());
+    // JDK-8094172: JavaFX needs Page instance
+    m_handle = m_socketProvider->createSocketStreamHandle(m_handshake->url(), *this, identifier(), page->sessionID(), page, partition, frame->loader().networkingContext());
+    return ConnectStatus::OK;
+}
+
+Document* WebSocketChannel::document()
+{
+    return m_document.get();
+}
+
+String WebSocketChannel::subprotocol()
+{
+    LOG(Network, "WebSocketChannel %p subprotocol()", this);
+    if (!m_handshake || m_handshake->mode() != WebSocketHandshake::Connected)
+        return emptyString();
+    String serverProtocol = m_handshake->serverWebSocketProtocol();
+    if (serverProtocol.isNull())
+        return emptyString();
+    return serverProtocol;
+}
+
+String WebSocketChannel::extensions()
+{
+    LOG(Network, "WebSocketChannel %p extensions()", this);
+    if (!m_handshake || m_handshake->mode() != WebSocketHandshake::Connected)
+        return emptyString();
+    String extensions = m_handshake->acceptedExtensions();
+    if (extensions.isNull())
+        return emptyString();
+    return extensions;
+}
+
+ThreadableWebSocketChannel::SendResult WebSocketChannel::send(CString&& message)
+{
+    if (m_outgoingFrameQueueStatus != OutgoingFrameQueueOpen)
+        return ThreadableWebSocketChannel::SendSuccess;
+
+    LOG(Network, "WebSocketChannel %p send() Sending String '%s'", this, message.data());
+    enqueueTextFrame(WTFMove(message));
+    processOutgoingFrameQueue();
+    // According to WebSocket API specification, WebSocket.send() should return void instead
+    // of boolean. However, our implementation still returns boolean due to compatibility
+    // concern (see bug 65850).
+    // m_channel->send() may happen later, thus it's not always possible to know whether
+    // the message has been sent to the socket successfully. In this case, we have no choice
+    // but to return true.
+    return ThreadableWebSocketChannel::SendSuccess;
+}
+
+ThreadableWebSocketChannel::SendResult WebSocketChannel::send(const ArrayBuffer& binaryData, unsigned byteOffset, unsigned byteLength)
+{
+    if (m_outgoingFrameQueueStatus != OutgoingFrameQueueOpen)
+        return ThreadableWebSocketChannel::SendSuccess;
+
+    LOG(Network, "WebSocketChannel %p send() Sending ArrayBuffer %p byteOffset=%u byteLength=%u", this, &binaryData, byteOffset, byteLength);
+    enqueueRawFrame(WebSocketFrame::OpCodeBinary, static_cast<const uint8_t*>(binaryData.data()) + byteOffset, byteLength);
+    processOutgoingFrameQueue();
+    return ThreadableWebSocketChannel::SendSuccess;
+}
+
+ThreadableWebSocketChannel::SendResult WebSocketChannel::send(Blob& binaryData)
+{
+    if (m_outgoingFrameQueueStatus != OutgoingFrameQueueOpen)
+        return ThreadableWebSocketChannel::SendSuccess;
+
+    LOG(Network, "WebSocketChannel %p send() Sending Blob '%s'", this, binaryData.url().string().utf8().data());
+    enqueueBlobFrame(WebSocketFrame::OpCodeBinary, binaryData);
+    processOutgoingFrameQueue();
+    return ThreadableWebSocketChannel::SendSuccess;
+}
+
+bool WebSocketChannel::send(const uint8_t* data, int length)
+{
+    if (m_outgoingFrameQueueStatus != OutgoingFrameQueueOpen)
+        return ThreadableWebSocketChannel::SendSuccess;
+
+    LOG(Network, "WebSocketChannel %p send() Sending uint8_t* data=%p length=%d", this, data, length);
+    enqueueRawFrame(WebSocketFrame::OpCodeBinary, data, length);
+    processOutgoingFrameQueue();
+    return true;
+}
+
+unsigned WebSocketChannel::bufferedAmount() const
+{
+    LOG(Network, "WebSocketChannel %p bufferedAmount()", this);
+    ASSERT(m_handle);
+    ASSERT(!m_suspended);
+    return m_handle->bufferedAmount();
+}
+
+void WebSocketChannel::close(int code, const String& reason)
+{
+    LOG(Network, "WebSocketChannel %p close() code=%d reason='%s'", this, code, reason.utf8().data());
+    ASSERT(!m_suspended);
+    if (!m_handle)
+        return;
+    Ref<WebSocketChannel> protectedThis(*this); // An attempt to send closing handshake may fail, which will get the channel closed and dereferenced.
+    startClosingHandshake(code, reason);
+    if (m_closing && !m_closingTimer.isActive())
+        m_closingTimer.startOneShot(TCPMaximumSegmentLifetime * 2);
+}
+
+void WebSocketChannel::fail(String&& reason)
+{
+    RELEASE_LOG(Network, "WebSocketChannel %p fail() reason='%s'", this, reason.utf8().data());
+    ASSERT(!m_suspended);
+    if (m_document) {
+        InspectorInstrumentation::didReceiveWebSocketFrameError(m_document.get(), m_progressIdentifier, reason);
+
+        String consoleMessage;
+        if (m_handshake)
+            consoleMessage = makeString("WebSocket connection to '", m_handshake->url().stringCenterEllipsizedToLength(), "' failed: ", reason);
+        else
+            consoleMessage = makeString("WebSocket connection failed: ", reason);
+
+        m_document->addConsoleMessage(MessageSource::Network, MessageLevel::Error, consoleMessage);
+    }
+
+    // Hybi-10 specification explicitly states we must not continue to handle incoming data
+    // once the WebSocket connection is failed (section 7.1.7).
+    Ref<WebSocketChannel> protectedThis(*this); // The client can close the channel, potentially removing the last reference.
+    m_shouldDiscardReceivedData = true;
+    if (!m_buffer.isEmpty())
+        skipBuffer(m_buffer.size()); // Save memory.
+    m_deflateFramer.didFail();
+    m_hasContinuousFrame = false;
+    m_continuousFrameData.clear();
+    if (m_client)
+        m_client->didReceiveMessageError(WTFMove(reason));
+
+    if (m_handle && !m_closed)
+        m_handle->disconnect(); // Will call didCloseSocketStream() but maybe not synchronously.
+}
+
+void WebSocketChannel::disconnect()
+{
+    LOG(Network, "WebSocketChannel %p disconnect()", this);
+    if (m_progressIdentifier && m_document)
+        InspectorInstrumentation::didCloseWebSocket(m_document.get(), m_progressIdentifier);
+    m_client = nullptr;
+    m_document = nullptr;
+    if (m_handle)
+        m_handle->disconnect();
+}
+
+void WebSocketChannel::suspend()
+{
+    m_suspended = true;
+}
+
+void WebSocketChannel::resume()
+{
+    m_suspended = false;
+    if ((!m_buffer.isEmpty() || m_closed) && m_client && !m_resumeTimer.isActive())
+        m_resumeTimer.startOneShot(0_s);
+}
+
+void WebSocketChannel::didOpenSocketStream(SocketStreamHandle& handle)
+{
+    LOG(Network, "WebSocketChannel %p didOpenSocketStream()", this);
+    ASSERT(&handle == m_handle);
+    if (!m_document)
+        return;
+    if (m_progressIdentifier && UNLIKELY(InspectorInstrumentation::hasFrontends())) {
+        auto cookieRequestHeaderFieldValue = [document = m_document] (const URL& url) -> String {
+            if (!document || !document->page())
+                return { };
+            return document->page()->cookieJar().cookieRequestHeaderFieldValue(*document, url);
+        };
+        InspectorInstrumentation::willSendWebSocketHandshakeRequest(m_document.get(), m_progressIdentifier, m_handshake->clientHandshakeRequest(WTFMove(cookieRequestHeaderFieldValue)));
+    }
+    auto handshakeMessage = m_handshake->clientHandshakeMessage();
+    std::optional<CookieRequestHeaderFieldProxy> cookieRequestHeaderFieldProxy;
+    if (m_allowCookies)
+        cookieRequestHeaderFieldProxy = CookieJar::cookieRequestHeaderFieldProxy(*m_document, m_handshake->httpURLForAuthenticationAndCookies());
+    handle.sendHandshake(WTFMove(handshakeMessage), WTFMove(cookieRequestHeaderFieldProxy), [this, protectedThis = Ref { *this }] (bool success, bool didAccessSecureCookies) {
+        if (!success)
+            fail("Failed to send WebSocket handshake."_s);
+
+        if (didAccessSecureCookies && m_document)
+            m_document->setSecureCookiesAccessed();
+    });
+}
+
+void WebSocketChannel::didCloseSocketStream(SocketStreamHandle& handle)
+{
+    LOG(Network, "WebSocketChannel %p didCloseSocketStream()", this);
+    if (m_progressIdentifier && m_document)
+        InspectorInstrumentation::didCloseWebSocket(m_document.get(), m_progressIdentifier);
+    ASSERT_UNUSED(handle, &handle == m_handle || !m_handle);
+    m_closed = true;
+    if (m_closingTimer.isActive())
+        m_closingTimer.stop();
+    if (m_outgoingFrameQueueStatus != OutgoingFrameQueueClosed)
+        abortOutgoingFrameQueue();
+    if (m_handle) {
+        m_unhandledBufferedAmount = m_handle->bufferedAmount();
+        if (m_suspended)
+            return;
+        WebSocketChannelClient* client = m_client.get();
+        m_client = nullptr;
+        m_document = nullptr;
+        m_handle = nullptr;
+        if (client)
+            client->didClose(m_unhandledBufferedAmount, m_receivedClosingHandshake ? WebSocketChannelClient::ClosingHandshakeComplete : WebSocketChannelClient::ClosingHandshakeIncomplete, m_closeEventCode, m_closeEventReason);
+    }
+    deref();
+}
+
+void WebSocketChannel::didReceiveSocketStreamData(SocketStreamHandle& handle, const uint8_t* data, size_t length)
+{
+    LOG(Network, "WebSocketChannel %p didReceiveSocketStreamData() Received %zu bytes", this, length);
+    Ref<WebSocketChannel> protectedThis(*this); // The client can close the channel, potentially removing the last reference.
+    ASSERT(&handle == m_handle);
+    if (!m_document) {
+        return;
+    }
+    if (!length) {
+        handle.disconnect();
+        return;
+    }
+    if (!m_client) {
+        m_shouldDiscardReceivedData = true;
+        handle.disconnect();
+        return;
+    }
+    if (m_shouldDiscardReceivedData)
+        return;
+    if (!appendToBuffer(data, length)) {
+        m_shouldDiscardReceivedData = true;
+        fail("Ran out of memory while receiving WebSocket data."_s);
+        return;
+    }
+    while (!m_suspended && m_client && !m_buffer.isEmpty()) {
+        if (!processBuffer())
+            break;
+    }
+}
+
+void WebSocketChannel::didFailToReceiveSocketStreamData(SocketStreamHandle& handle)
+{
+    handle.disconnect();
+}
+
+void WebSocketChannel::didUpdateBufferedAmount(SocketStreamHandle&, size_t bufferedAmount)
+{
+    if (m_client)
+        m_client->didUpdateBufferedAmount(bufferedAmount);
+}
+
+void WebSocketChannel::didFailSocketStream(SocketStreamHandle& handle, const SocketStreamError& error)
+{
+    LOG(Network, "WebSocketChannel %p didFailSocketStream()", this);
+    ASSERT(&handle == m_handle || !m_handle);
+
+        String message;
+        if (error.isNull())
+            message = "WebSocket network error"_s;
+        else if (error.localizedDescription().isNull())
+            message = makeString("WebSocket network error: error code ", error.errorCode());
+        else
+            message = "WebSocket network error: " + error.localizedDescription();
+
+    if (m_document) {
+        InspectorInstrumentation::didReceiveWebSocketFrameError(m_document.get(), m_progressIdentifier, message);
+        m_document->addConsoleMessage(MessageSource::Network, MessageLevel::Error, message);
+        LOG_ERROR("%s", message.utf8().data());
+    }
+    m_shouldDiscardReceivedData = true;
+    if (m_client)
+        m_client->didReceiveMessageError(WTFMove(message));
+    handle.disconnect();
+}
+
+void WebSocketChannel::didStartLoading()
+{
+    LOG(Network, "WebSocketChannel %p didStartLoading()", this);
+    ASSERT(m_blobLoader);
+    ASSERT(m_blobLoaderStatus == BlobLoaderStarted);
+}
+
+void WebSocketChannel::didReceiveData()
+{
+    LOG(Network, "WebSocketChannel %p didReceiveData()", this);
+    ASSERT(m_blobLoader);
+    ASSERT(m_blobLoaderStatus == BlobLoaderStarted);
+}
+
+void WebSocketChannel::didFinishLoading()
+{
+    LOG(Network, "WebSocketChannel %p didFinishLoading()", this);
+    ASSERT(m_blobLoader);
+    ASSERT(m_blobLoaderStatus == BlobLoaderStarted);
+    m_blobLoaderStatus = BlobLoaderFinished;
+    processOutgoingFrameQueue();
+    deref();
+}
+
+void WebSocketChannel::didFail(ExceptionCode errorCode)
+{
+    auto code = static_cast<int>(errorCode);
+    LOG(Network, "WebSocketChannel %p didFail() errorCode=%d", this, code);
+    ASSERT(m_blobLoader);
+    ASSERT(m_blobLoaderStatus == BlobLoaderStarted);
+    m_blobLoader = nullptr;
+    m_blobLoaderStatus = BlobLoaderFailed;
+    fail(makeString("Failed to load Blob: error code = ", code)); // FIXME: Generate human-friendly reason message.
+    deref();
+}
+
+bool WebSocketChannel::appendToBuffer(const uint8_t* data, size_t len)
+{
+    size_t newBufferSize = m_buffer.size() + len;
+    if (newBufferSize < m_buffer.size()) {
+        LOG(Network, "WebSocketChannel %p appendToBuffer() Buffer overflow (%u bytes already in receive buffer and appending %u bytes)", this, static_cast<unsigned>(m_buffer.size()), static_cast<unsigned>(len));
+        return false;
+    }
+    m_buffer.append(data, len);
+    return true;
+}
+
+void WebSocketChannel::skipBuffer(size_t len)
+{
+    ASSERT_WITH_SECURITY_IMPLICATION(len <= m_buffer.size());
+    memmove(m_buffer.data(), m_buffer.data() + len, m_buffer.size() - len);
+    m_buffer.shrink(m_buffer.size() - len);
+}
+
+bool WebSocketChannel::processBuffer()
+{
+    ASSERT(!m_suspended);
+    ASSERT(m_client);
+    ASSERT(!m_buffer.isEmpty());
+    LOG(Network, "WebSocketChannel %p processBuffer() Receive buffer has %u bytes", this, static_cast<unsigned>(m_buffer.size()));
+
+    if (m_shouldDiscardReceivedData)
+        return false;
+
+    if (m_receivedClosingHandshake) {
+        skipBuffer(m_buffer.size());
+        return false;
+    }
+
+    Ref<WebSocketChannel> protectedThis(*this); // The client can close the channel, potentially removing the last reference.
+
+    if (m_handshake->mode() == WebSocketHandshake::Incomplete) {
+        int headerLength = m_handshake->readServerHandshake(m_buffer.data(), m_buffer.size());
+        if (headerLength <= 0)
+            return false;
+        if (m_handshake->mode() == WebSocketHandshake::Connected) {
+            if (m_progressIdentifier)
+                InspectorInstrumentation::didReceiveWebSocketHandshakeResponse(m_document.get(), m_progressIdentifier, m_handshake->serverHandshakeResponse());
+            String serverSetCookie = m_handshake->serverSetCookie();
+            if (!serverSetCookie.isEmpty()) {
+                if (m_document && m_document->page() && m_document->page()->cookieJar().cookiesEnabled(*m_document))
+                    m_document->page()->cookieJar().setCookies(*m_document, m_handshake->httpURLForAuthenticationAndCookies(), serverSetCookie);
+            }
+            LOG(Network, "WebSocketChannel %p Connected", this);
+            skipBuffer(headerLength);
+            m_client->didConnect();
+            LOG(Network, "WebSocketChannel %p %u bytes remaining in m_buffer", this, static_cast<unsigned>(m_buffer.size()));
+            return !m_buffer.isEmpty();
+        }
+        ASSERT(m_handshake->mode() == WebSocketHandshake::Failed);
+        LOG(Network, "WebSocketChannel %p Connection failed", this);
+        skipBuffer(headerLength);
+        m_shouldDiscardReceivedData = true;
+        fail(m_handshake->failureReason());
+        return false;
+    }
+    if (m_handshake->mode() != WebSocketHandshake::Connected)
+        return false;
+
+    return processFrame();
+}
+
+void WebSocketChannel::resumeTimerFired()
+{
+    Ref<WebSocketChannel> protectedThis(*this); // The client can close the channel, potentially removing the last reference.
+    while (!m_suspended && m_client && !m_buffer.isEmpty())
+        if (!processBuffer())
+            break;
+    if (!m_suspended && m_client && m_closed && m_handle)
+        didCloseSocketStream(*m_handle);
+}
+
+void WebSocketChannel::startClosingHandshake(int code, const String& reason)
+{
+    LOG(Network, "WebSocketChannel %p startClosingHandshake() code=%d m_receivedClosingHandshake=%d", this, m_closing, m_receivedClosingHandshake);
+    ASSERT(!m_closed);
+    if (m_closing)
+        return;
+    ASSERT(m_handle);
+
+    Vector<uint8_t> buf;
+    if (!m_receivedClosingHandshake && code != CloseEventCodeNotSpecified) {
+        uint8_t highByte = code >> 8;
+        uint8_t lowByte = code;
+        buf.append(highByte);
+        buf.append(lowByte);
+        auto reasonUTF8 = reason.utf8();
+        buf.append(reasonUTF8.dataAsUInt8Ptr(), reasonUTF8.length());
+    }
+    enqueueRawFrame(WebSocketFrame::OpCodeClose, buf.data(), buf.size());
+    Ref<WebSocketChannel> protectedThis(*this); // An attempt to send closing handshake may fail, which will get the channel closed and dereferenced.
+    processOutgoingFrameQueue();
+
+    if (m_closed) {
+        // The channel got closed because processOutgoingFrameQueue() failed.
+        return;
+    }
+
+    m_closing = true;
+    if (m_client)
+        m_client->didStartClosingHandshake();
+}
+
+void WebSocketChannel::closingTimerFired()
+{
+    LOG(Network, "WebSocketChannel %p closingTimerFired()", this);
+    if (m_handle)
+        m_handle->disconnect();
+}
+
+
+bool WebSocketChannel::processFrame()
+{
+    ASSERT(!m_buffer.isEmpty());
+
+    WebSocketFrame frame;
+    const uint8_t* frameEnd;
+    String errorString;
+    WebSocketFrame::ParseFrameResult result = WebSocketFrame::parseFrame(m_buffer.data(), m_buffer.size(), frame, frameEnd, errorString);
+    if (result == WebSocketFrame::FrameIncomplete)
+        return false;
+    if (result == WebSocketFrame::FrameError) {
+        fail(WTFMove(errorString));
+        return false;
+    }
+
+    ASSERT(m_buffer.data() < frameEnd);
+    ASSERT(frameEnd <= m_buffer.data() + m_buffer.size());
+
+    auto inflateResult = m_deflateFramer.inflate(frame);
+    if (!inflateResult->succeeded()) {
+        fail(inflateResult->failureReason());
+        return false;
+    }
+
+    // Validate the frame data.
+    if (WebSocketFrame::isReservedOpCode(frame.opCode)) {
+        fail(makeString("Unrecognized frame opcode: ", static_cast<unsigned>(frame.opCode)));
+        return false;
+    }
+
+    if (frame.reserved2 || frame.reserved3) {
+        fail(makeString("One or more reserved bits are on: reserved2 = ", static_cast<unsigned>(frame.reserved2), ", reserved3 = ", static_cast<unsigned>(frame.reserved3)));
+        return false;
+    }
+
+    if (frame.masked) {
+        fail("A server must not mask any frames that it sends to the client."_s);
+        return false;
+    }
+
+    // All control frames must not be fragmented.
+    if (WebSocketFrame::isControlOpCode(frame.opCode) && !frame.final) {
+        fail(makeString("Received fragmented control frame: opcode = ", static_cast<unsigned>(frame.opCode)));
+        return false;
+    }
+
+    // All control frames must have a payload of 125 bytes or less, which means the frame must not contain
+    // the "extended payload length" field.
+    if (WebSocketFrame::isControlOpCode(frame.opCode) && WebSocketFrame::needsExtendedLengthField(frame.payloadLength)) {
+        fail(makeString("Received control frame having too long payload: ", frame.payloadLength, " bytes"));
+        return false;
+    }
+
+    // A new data frame is received before the previous continuous frame finishes.
+    // Note that control frames are allowed to come in the middle of continuous frames.
+    if (m_hasContinuousFrame && frame.opCode != WebSocketFrame::OpCodeContinuation && !WebSocketFrame::isControlOpCode(frame.opCode)) {
+        fail("Received new data frame but previous continuous frame is unfinished."_s);
+        return false;
+    }
+
+    InspectorInstrumentation::didReceiveWebSocketFrame(m_document.get(), m_progressIdentifier, frame);
+
+    switch (frame.opCode) {
+    case WebSocketFrame::OpCodeContinuation:
+        // An unexpected continuation frame is received without any leading frame.
+        if (!m_hasContinuousFrame) {
+            fail("Received unexpected continuation frame."_s);
+            return false;
+        }
+        m_continuousFrameData.append(frame.payload, frame.payloadLength);
+        skipBuffer(frameEnd - m_buffer.data());
+        if (frame.final) {
+            // onmessage handler may eventually call the other methods of this channel,
+            // so we should pretend that we have finished to read this frame and
+            // make sure that the member variables are in a consistent state before
+            // the handler is invoked.
+            Vector<uint8_t> continuousFrameData = WTFMove(m_continuousFrameData);
+            m_hasContinuousFrame = false;
+            if (m_continuousFrameOpCode == WebSocketFrame::OpCodeText) {
+                String message;
+                if (continuousFrameData.size())
+                    message = String::fromUTF8(continuousFrameData.data(), continuousFrameData.size());
+                else
+                    message = emptyString();
+                if (message.isNull())
+                    fail("Could not decode a text frame as UTF-8."_s);
+                else
+                    m_client->didReceiveMessage(WTFMove(message));
+            } else if (m_continuousFrameOpCode == WebSocketFrame::OpCodeBinary)
+                m_client->didReceiveBinaryData(WTFMove(continuousFrameData));
+        }
+        break;
+
+    case WebSocketFrame::OpCodeText:
+        if (frame.final) {
+            String message;
+            if (frame.payloadLength)
+                message = String::fromUTF8(frame.payload, frame.payloadLength);
+            else
+                message = emptyString();
+            skipBuffer(frameEnd - m_buffer.data());
+            if (message.isNull())
+                fail("Could not decode a text frame as UTF-8."_s);
+            else
+                m_client->didReceiveMessage(WTFMove(message));
+        } else {
+            m_hasContinuousFrame = true;
+            m_continuousFrameOpCode = WebSocketFrame::OpCodeText;
+            ASSERT(m_continuousFrameData.isEmpty());
+            m_continuousFrameData.append(frame.payload, frame.payloadLength);
+            skipBuffer(frameEnd - m_buffer.data());
+        }
+        break;
+
+    case WebSocketFrame::OpCodeBinary:
+        if (frame.final) {
+            Vector<uint8_t> binaryData(frame.payloadLength);
+            memcpy(binaryData.data(), frame.payload, frame.payloadLength);
+            skipBuffer(frameEnd - m_buffer.data());
+            m_client->didReceiveBinaryData(WTFMove(binaryData));
+        } else {
+            m_hasContinuousFrame = true;
+            m_continuousFrameOpCode = WebSocketFrame::OpCodeBinary;
+            ASSERT(m_continuousFrameData.isEmpty());
+            m_continuousFrameData.append(frame.payload, frame.payloadLength);
+            skipBuffer(frameEnd - m_buffer.data());
+        }
+        break;
+
+    case WebSocketFrame::OpCodeClose:
+        if (!frame.payloadLength)
+            m_closeEventCode = CloseEventCodeNoStatusRcvd;
+        else if (frame.payloadLength == 1) {
+            m_closeEventCode = CloseEventCodeAbnormalClosure;
+            fail("Received a broken close frame containing an invalid size body."_s);
+            return false;
+        } else {
+            m_closeEventCode = frame.payload[0] << 8 | frame.payload[1];
+            if (m_closeEventCode == CloseEventCodeNoStatusRcvd || m_closeEventCode == CloseEventCodeAbnormalClosure || m_closeEventCode == CloseEventCodeTLSHandshake) {
+                m_closeEventCode = CloseEventCodeAbnormalClosure;
+                fail("Received a broken close frame containing a reserved status code."_s);
+                return false;
+            }
+        }
+        if (frame.payloadLength >= 3)
+            m_closeEventReason = String::fromUTF8(&frame.payload[2], frame.payloadLength - 2);
+        else
+            m_closeEventReason = emptyString();
+        skipBuffer(frameEnd - m_buffer.data());
+        m_receivedClosingHandshake = true;
+        startClosingHandshake(m_closeEventCode, m_closeEventReason);
+        if (m_closing) {
+            if (m_outgoingFrameQueueStatus == OutgoingFrameQueueOpen)
+                m_outgoingFrameQueueStatus = OutgoingFrameQueueClosing;
+            processOutgoingFrameQueue();
+        }
+        break;
+
+    case WebSocketFrame::OpCodePing:
+        enqueueRawFrame(WebSocketFrame::OpCodePong, frame.payload, frame.payloadLength);
+        skipBuffer(frameEnd - m_buffer.data());
+        processOutgoingFrameQueue();
+        break;
+
+    case WebSocketFrame::OpCodePong:
+        // A server may send a pong in response to our ping, or an unsolicited pong which is not associated with
+        // any specific ping. Either way, there's nothing to do on receipt of pong.
+        skipBuffer(frameEnd - m_buffer.data());
+        break;
+
+    default:
+        ASSERT_NOT_REACHED();
+        skipBuffer(frameEnd - m_buffer.data());
+        break;
+    }
+
+    if (m_buffer.isEmpty()) {
+        m_buffer.clear();
+        return false;
+    }
+    return true;
+}
+
+void WebSocketChannel::enqueueTextFrame(CString&& string)
+{
+    ASSERT(m_outgoingFrameQueueStatus == OutgoingFrameQueueOpen);
+    auto frame = makeUnique<QueuedFrame>();
+    frame->opCode = WebSocketFrame::OpCodeText;
+    frame->frameType = QueuedFrameTypeString;
+    frame->stringData = WTFMove(string);
+    m_outgoingFrameQueue.append(WTFMove(frame));
+}
+
+void WebSocketChannel::enqueueRawFrame(WebSocketFrame::OpCode opCode, const uint8_t* data, size_t dataLength)
+{
+    ASSERT(m_outgoingFrameQueueStatus == OutgoingFrameQueueOpen);
+    auto frame = makeUnique<QueuedFrame>();
+    frame->opCode = opCode;
+    frame->frameType = QueuedFrameTypeVector;
+    frame->vectorData = { data, dataLength };
+    m_outgoingFrameQueue.append(WTFMove(frame));
+}
+
+void WebSocketChannel::enqueueBlobFrame(WebSocketFrame::OpCode opCode, Blob& blob)
+{
+    ASSERT(m_outgoingFrameQueueStatus == OutgoingFrameQueueOpen);
+    auto frame = makeUnique<QueuedFrame>();
+    frame->opCode = opCode;
+    frame->frameType = QueuedFrameTypeBlob;
+    frame->blobData = &blob;
+    m_outgoingFrameQueue.append(WTFMove(frame));
+}
+
+void WebSocketChannel::processOutgoingFrameQueue()
+{
+    if (m_outgoingFrameQueueStatus == OutgoingFrameQueueClosed)
+        return;
+
+    Ref<WebSocketChannel> protectedThis(*this); // Any call to fail() will get the channel closed and dereferenced.
+
+    while (!m_outgoingFrameQueue.isEmpty()) {
+        auto frame = m_outgoingFrameQueue.takeFirst();
+        switch (frame->frameType) {
+        case QueuedFrameTypeString: {
+            sendFrame(frame->opCode, frame->stringData.dataAsUInt8Ptr(), frame->stringData.length(), [this, protectedThis = Ref { *this }] (bool success) {
+                if (!success)
+                    fail("Failed to send WebSocket frame."_s);
+            });
+            break;
+        }
+
+        case QueuedFrameTypeVector:
+            sendFrame(frame->opCode, frame->vectorData.data(), frame->vectorData.size(), [this, protectedThis = Ref { *this }] (bool success) {
+                if (!success)
+                    fail("Failed to send WebSocket frame."_s);
+            });
+            break;
+
+        case QueuedFrameTypeBlob: {
+            switch (m_blobLoaderStatus) {
+            case BlobLoaderNotStarted:
+                ref(); // Will be derefed after didFinishLoading() or didFail().
+                ASSERT(!m_blobLoader);
+                ASSERT(frame->blobData);
+                m_blobLoader = makeUnique<FileReaderLoader>(FileReaderLoader::ReadAsArrayBuffer, this);
+                m_blobLoaderStatus = BlobLoaderStarted;
+                m_blobLoader->start(m_document.get(), *frame->blobData);
+                m_outgoingFrameQueue.prepend(WTFMove(frame));
+                return;
+
+            case BlobLoaderStarted:
+            case BlobLoaderFailed:
+                m_outgoingFrameQueue.prepend(WTFMove(frame));
+                return;
+
+            case BlobLoaderFinished: {
+                RefPtr<ArrayBuffer> result = m_blobLoader->arrayBufferResult();
+                m_blobLoader = nullptr;
+                m_blobLoaderStatus = BlobLoaderNotStarted;
+                sendFrame(frame->opCode, static_cast<const uint8_t*>(result->data()), result->byteLength(), [this, protectedThis = Ref { *this }] (bool success) {
+                    if (!success)
+                        fail("Failed to send WebSocket frame."_s);
+                });
+                break;
+            }
+            }
+            break;
+        }
+
+        default:
+            ASSERT_NOT_REACHED();
+            break;
+        }
+    }
+
+    ASSERT(m_outgoingFrameQueue.isEmpty());
+    if (m_outgoingFrameQueueStatus == OutgoingFrameQueueClosing) {
+        m_outgoingFrameQueueStatus = OutgoingFrameQueueClosed;
+        m_handle->close();
+    }
+}
+
+void WebSocketChannel::abortOutgoingFrameQueue()
+{
+    m_outgoingFrameQueue.clear();
+    m_outgoingFrameQueueStatus = OutgoingFrameQueueClosed;
+    if (m_blobLoaderStatus == BlobLoaderStarted) {
+        m_blobLoader->cancel();
+        didFail(ExceptionCode::AbortError);
+    }
+}
+
+void WebSocketChannel::sendFrame(WebSocketFrame::OpCode opCode, const uint8_t* data, size_t dataLength, Function<void(bool)> completionHandler)
+{
+    ASSERT(m_handle);
+    ASSERT(!m_suspended);
+
+    WebSocketFrame frame(opCode, true, false, true, data, dataLength);
+    InspectorInstrumentation::didSendWebSocketFrame(m_document.get(), m_progressIdentifier, frame);
+
+    auto deflateResult = m_deflateFramer.deflate(frame);
+    if (!deflateResult->succeeded()) {
+        fail(deflateResult->failureReason());
+        return completionHandler(false);
+    }
+
+    Vector<uint8_t> frameData;
+    frame.makeFrameData(frameData);
+
+    m_handle->sendData(frameData.data(), frameData.size(), WTFMove(completionHandler));
+}
+
+ResourceRequest WebSocketChannel::clientHandshakeRequest(const CookieGetter& cookieRequestHeaderFieldValue) const
+{
+    return m_handshake->clientHandshakeRequest(cookieRequestHeaderFieldValue);
+}
+
+const ResourceResponse& WebSocketChannel::serverHandshakeResponse() const
+{
+    return m_handshake->serverHandshakeResponse();
+}
+
+} // namespace WebCore
+#endif

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/websockets/WebSocketChannel.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/websockets/WebSocketChannel.h
@@ -1,0 +1,237 @@
+/*
+ * Copyright (C) 2011, 2012 Google Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+#if PLATFORM(JAVA)
+#include "ExceptionCode.h"
+#include "FileReaderLoaderClient.h"
+#include "SocketStreamHandleClient.h"
+#include "ThreadableWebSocketChannel.h"
+#include "Timer.h"
+#include "WebSocketChannelInspector.h"
+#include "WebSocketDeflateFramer.h"
+#include "WebSocketFrame.h"
+#include "WebSocketHandshake.h"
+#include <wtf/Deque.h>
+#include <wtf/Forward.h>
+#include <wtf/ObjectIdentifier.h>
+#include <wtf/RefCounted.h>
+#include <wtf/TypeCasts.h>
+#include <wtf/Vector.h>
+#include <wtf/text/CString.h>
+
+namespace WebCore {
+
+class Blob;
+class Document;
+class FileReaderLoader;
+class ResourceRequest;
+class ResourceResponse;
+class SocketProvider;
+class SocketStreamHandle;
+class SocketStreamError;
+class WebSocketChannelClient;
+class WebSocketChannel;
+using WebSocketChannelIdentifier = AtomicObjectIdentifier<WebSocketChannel>;
+
+class WebSocketChannel final : public RefCounted<WebSocketChannel>, public SocketStreamHandleClient, public ThreadableWebSocketChannel, public FileReaderLoaderClient
+{
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    static Ref<WebSocketChannel> create(Document& document, WebSocketChannelClient& client, SocketProvider& provider) { return adoptRef(*new WebSocketChannel(document, client, provider)); }
+    virtual ~WebSocketChannel();
+
+    bool send(const uint8_t* data, int length);
+
+    // ThreadableWebSocketChannel functions.
+    ConnectStatus connect(const URL&, const String& protocol) final;
+    String subprotocol() final;
+    String extensions() final;
+    ThreadableWebSocketChannel::SendResult send(CString&&) final;
+    ThreadableWebSocketChannel::SendResult send(const JSC::ArrayBuffer&, unsigned byteOffset, unsigned byteLength) final;
+    ThreadableWebSocketChannel::SendResult send(Blob&) final;
+    unsigned bufferedAmount() const final;
+    void close(int code, const String& reason) final; // Start closing handshake.
+    void fail(String&& reason) final;
+    void disconnect() final;
+
+    void suspend() final;
+    void resume() final;
+
+    // SocketStreamHandleClient functions.
+    void didOpenSocketStream(SocketStreamHandle&) final;
+    void didCloseSocketStream(SocketStreamHandle&) final;
+    void didReceiveSocketStreamData(SocketStreamHandle&, const uint8_t*, size_t) final;
+    void didFailToReceiveSocketStreamData(SocketStreamHandle&) final;
+    void didUpdateBufferedAmount(SocketStreamHandle&, size_t bufferedAmount) final;
+    void didFailSocketStream(SocketStreamHandle&, const SocketStreamError&) final;
+
+    enum CloseEventCode {
+        CloseEventCodeNotSpecified = -1,
+        CloseEventCodeNormalClosure = 1000,
+        CloseEventCodeGoingAway = 1001,
+        CloseEventCodeProtocolError = 1002,
+        CloseEventCodeUnsupportedData = 1003,
+        CloseEventCodeFrameTooLarge = 1004,
+        CloseEventCodeNoStatusRcvd = 1005,
+        CloseEventCodeAbnormalClosure = 1006,
+        CloseEventCodeInvalidFramePayloadData = 1007,
+        CloseEventCodePolicyViolation = 1008,
+        CloseEventCodeMessageTooBig = 1009,
+        CloseEventCodeMandatoryExt = 1010,
+        CloseEventCodeInternalError = 1011,
+        CloseEventCodeTLSHandshake = 1015,
+        CloseEventCodeMinimumUserDefined = 3000,
+        CloseEventCodeMaximumUserDefined = 4999
+    };
+
+    // FileReaderLoaderClient functions.
+    void didStartLoading() override;
+    void didReceiveData() override;
+    void didFinishLoading() override;
+    void didFail(ExceptionCode errorCode) override;
+
+    WebSocketChannelIdentifier progressIdentifier() const final { return m_progressIdentifier; }
+    bool hasCreatedHandshake() const final { return !!m_handshake; }
+    bool isConnected() const final { return m_handshake->mode() == WebSocketHandshake::Mode::Connected; }
+    ResourceRequest clientHandshakeRequest(const CookieGetter&) const final;
+    const ResourceResponse& serverHandshakeResponse() const final;
+
+    using RefCounted<WebSocketChannel>::ref;
+    using RefCounted<WebSocketChannel>::deref;
+
+    Document* document();
+
+private:
+    WEBCORE_EXPORT WebSocketChannel(Document&, WebSocketChannelClient&, SocketProvider&);
+
+    void refThreadableWebSocketChannel() override { ref(); }
+    void derefThreadableWebSocketChannel() override { deref(); }
+
+    bool appendToBuffer(const uint8_t* data, size_t len);
+    void skipBuffer(size_t len);
+    bool processBuffer();
+    void resumeTimerFired();
+    void startClosingHandshake(int code, const String& reason);
+    void closingTimerFired();
+
+    bool processFrame();
+
+    // It is allowed to send a Blob as a binary frame if hybi-10 protocol is in use. Sending a Blob
+    // can be delayed because it must be read asynchronously. Other types of data (String or
+    // ArrayBuffer) may also be blocked by preceding sending request of a Blob.
+    //
+    // To address this situation, messages to be sent need to be stored in a queue. Whenever a new
+    // data frame is going to be sent, it first must go to the queue. Items in the queue are processed
+    // in the order they were put into the queue. Sending request of a Blob blocks further processing
+    // until the Blob is completely read and sent to the socket stream.
+    enum QueuedFrameType {
+        QueuedFrameTypeString,
+        QueuedFrameTypeVector,
+        QueuedFrameTypeBlob
+    };
+    struct QueuedFrame {
+        WTF_MAKE_STRUCT_FAST_ALLOCATED;
+
+        WebSocketFrame::OpCode opCode;
+        QueuedFrameType frameType;
+        // Only one of the following items is used, according to the value of frameType.
+        CString stringData;
+        Vector<uint8_t> vectorData;
+        RefPtr<Blob> blobData;
+    };
+    void enqueueTextFrame(CString&&);
+    void enqueueRawFrame(WebSocketFrame::OpCode, const uint8_t* data, size_t dataLength);
+    void enqueueBlobFrame(WebSocketFrame::OpCode, Blob&);
+
+    void processOutgoingFrameQueue();
+    void abortOutgoingFrameQueue();
+
+    enum OutgoingFrameQueueStatus {
+        // It is allowed to put a new item into the queue.
+        OutgoingFrameQueueOpen,
+        // Close frame has already been put into the queue but may not have been sent yet;
+        // m_handle->close() will be called as soon as the queue is cleared. It is not
+        // allowed to put a new item into the queue.
+        OutgoingFrameQueueClosing,
+        // Close frame has been sent or the queue was aborted. It is not allowed to put
+        // a new item to the queue.
+        OutgoingFrameQueueClosed
+    };
+
+    // If you are going to send a hybi-10 frame, you need to use the outgoing frame queue
+    // instead of call sendFrame() directly.
+    void sendFrame(WebSocketFrame::OpCode, const uint8_t* data, size_t dataLength, Function<void(bool)> completionHandler);
+
+    enum BlobLoaderStatus {
+        BlobLoaderNotStarted,
+        BlobLoaderStarted,
+        BlobLoaderFinished,
+        BlobLoaderFailed
+    };
+
+    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
+    WeakPtr<WebSocketChannelClient> m_client;
+    std::unique_ptr<WebSocketHandshake> m_handshake;
+    RefPtr<SocketStreamHandle> m_handle;
+    Vector<uint8_t> m_buffer;
+
+    Timer m_resumeTimer;
+    bool m_suspended { false };
+    bool m_closing { false };
+    bool m_receivedClosingHandshake { false };
+    bool m_allowCookies { true };
+    Timer m_closingTimer;
+    bool m_closed { false };
+    bool m_shouldDiscardReceivedData { false };
+    unsigned m_unhandledBufferedAmount { 0 };
+
+    WebSocketChannelIdentifier m_progressIdentifier;
+
+    // Private members only for hybi-10 protocol.
+    bool m_hasContinuousFrame { false };
+    WebSocketFrame::OpCode m_continuousFrameOpCode;
+    Vector<uint8_t> m_continuousFrameData;
+    unsigned short m_closeEventCode { CloseEventCodeAbnormalClosure };
+    String m_closeEventReason;
+
+    Deque<std::unique_ptr<QueuedFrame>> m_outgoingFrameQueue;
+    OutgoingFrameQueueStatus m_outgoingFrameQueueStatus { OutgoingFrameQueueOpen };
+
+    // FIXME: Load two or more Blobs simultaneously for better performance.
+    std::unique_ptr<FileReaderLoader> m_blobLoader;
+    BlobLoaderStatus m_blobLoaderStatus { BlobLoaderNotStarted };
+
+    WebSocketDeflateFramer m_deflateFramer;
+    Ref<SocketProvider> m_socketProvider;
+};
+
+} // namespace WebCore
+#endif

--- a/modules/javafx.web/src/main/native/Source/WebCore/Sources.txt
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Sources.txt
@@ -456,6 +456,7 @@ Modules/websockets/CloseEvent.cpp
 Modules/websockets/ThreadableWebSocketChannel.cpp
 Modules/websockets/ThreadableWebSocketChannelClientWrapper.cpp
 Modules/websockets/WebSocket.cpp
+Modules/websockets/WebSocketChannel.cpp
 Modules/websockets/WebSocketChannelInspector.cpp
 Modules/websockets/WebSocketDeflateFramer.cpp
 Modules/websockets/WebSocketDeflater.cpp
@@ -1956,6 +1957,7 @@ page/SecurityPolicy.cpp
 page/SettingsBase.cpp
 page/ShadowRealmGlobalScope.cpp
 page/ShareDataReader.cpp
+page/SocketProvider.cpp
 page/SpatialNavigation.cpp
 page/SuspendableTimer.cpp
 page/TextIndicator.cpp
@@ -2458,6 +2460,8 @@ platform/network/ResourceHandleClient.cpp
 platform/network/ResourceRequestBase.cpp
 platform/network/ResourceResponseBase.cpp
 platform/network/SameSiteInfo.cpp
+platform/network/SocketStreamHandle.cpp
+platform/network/SocketStreamHandleImpl.cpp
 platform/network/SynchronousLoaderClient.cpp
 platform/network/TimingAllowOrigin.cpp
 platform/sql/SQLiteAuthorizer.cpp

--- a/modules/javafx.web/src/main/native/Source/WebCore/SourcesJava.txt
+++ b/modules/javafx.web/src/main/native/Source/WebCore/SourcesJava.txt
@@ -101,6 +101,7 @@ platform/network/java/NetworkStateNotifierJava.cpp
 platform/network/java/NetworkStorageSessionJava.cpp
 platform/network/java/ResourceHandleJava.cpp
 platform/network/java/ResourceRequestJava.cpp
+platform/network/java/SocketStreamHandleImplJava.cpp
 platform/network/java/SynchronousLoaderClientJava.cpp
 platform/network/java/URLLoader.cpp
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/mapfile-macosx
+++ b/modules/javafx.web/src/main/native/Source/WebCore/mapfile-macosx
@@ -1790,6 +1790,10 @@
                _Java_com_sun_webkit_graphics_WCMediaPlayer_notifySeeking
                _Java_com_sun_webkit_graphics_WCMediaPlayer_notifySizeChanged
                _Java_com_sun_webkit_graphics_WCRenderQueue_twkRelease
+               _Java_com_sun_webkit_network_SocketStreamHandle_twkDidClose
+               _Java_com_sun_webkit_network_SocketStreamHandle_twkDidFail
+               _Java_com_sun_webkit_network_SocketStreamHandle_twkDidOpen
+               _Java_com_sun_webkit_network_SocketStreamHandle_twkDidReceiveData
                _Java_com_sun_webkit_network_URLLoaderBase_twkDidFail
                _Java_com_sun_webkit_network_URLLoaderBase_twkDidFinishLoading
                _Java_com_sun_webkit_network_URLLoaderBase_twkDidReceiveData

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/network/SocketStreamHandle.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/network/SocketStreamHandle.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2009, 2011, 2012 Google Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#if PLATFORM(JAVA)
+#include "SocketStreamHandle.h"
+
+#include "CookieRequestHeaderFieldProxy.h"
+#include "SocketStreamHandleClient.h"
+#include <wtf/Function.h>
+
+namespace WebCore {
+
+SocketStreamHandle::SocketStreamHandle(const URL& url, SocketStreamHandleClient& client)
+    : m_url(url)
+    , m_client(client)
+    , m_state(Connecting)
+{
+    ASSERT(isMainThread());
+}
+
+SocketStreamHandle::SocketStreamState SocketStreamHandle::state() const
+{
+    return m_state;
+}
+
+void SocketStreamHandle::sendData(const uint8_t* data, size_t length, Function<void(bool)> completionHandler)
+{
+    if (m_state == Connecting || m_state == Closing)
+        return completionHandler(false);
+    platformSend(data, length, WTFMove(completionHandler));
+}
+
+void SocketStreamHandle::sendHandshake(CString&& handshake, std::optional<CookieRequestHeaderFieldProxy>&& headerFieldProxy, Function<void(bool, bool)> completionHandler)
+{
+    if (m_state == Connecting || m_state == Closing)
+        return completionHandler(false, false);
+    platformSendHandshake(handshake.dataAsUInt8Ptr(), handshake.length(), WTFMove(headerFieldProxy), WTFMove(completionHandler));
+}
+
+void SocketStreamHandle::close()
+{
+    if (m_state == Closed)
+        return;
+    m_state = Closing;
+    if (bufferedAmount())
+        return;
+    disconnect();
+}
+
+void SocketStreamHandle::disconnect()
+{
+    Ref protect = static_cast<SocketStreamHandle&>(*this); // platformClose calls the client, which may make the handle get deallocated immediately.
+
+    platformClose();
+    m_state = Closed;
+}
+
+} // namespace WebCore
+#endif

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/network/SocketStreamHandle.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/network/SocketStreamHandle.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2009 Apple Inc. All rights reserved.
+ * Copyright (C) 2009, 2012 Google Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+#if PLATFORM(JAVA)
+#include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/URL.h>
+
+namespace WebCore {
+
+struct CookieRequestHeaderFieldProxy;
+class SocketStreamHandleClient;
+
+struct SourceApplicationAuditToken {
+#if PLATFORM(COCOA)
+    RetainPtr<CFDataRef> sourceApplicationAuditData;
+#else
+    void *empty { nullptr };
+#endif
+};
+
+class SocketStreamHandle : public ThreadSafeRefCounted<SocketStreamHandle, WTF::DestructionThread::Main> {
+public:
+    enum SocketStreamState { Connecting, Open, Closing, Closed };
+    virtual ~SocketStreamHandle() = default;
+    SocketStreamState state() const;
+
+    void sendData(const uint8_t* data, size_t length, Function<void(bool)>);
+    void sendHandshake(CString&& handshake, std::optional<CookieRequestHeaderFieldProxy>&&, Function<void(bool, bool)>);
+    void close(); // Disconnect after all data in buffer are sent.
+    void disconnect();
+    virtual size_t bufferedAmount() = 0;
+
+protected:
+    WEBCORE_EXPORT SocketStreamHandle(const URL&, SocketStreamHandleClient&);
+
+    virtual void platformSend(const uint8_t* data, size_t length, Function<void(bool)>&&) = 0;
+    virtual void platformSendHandshake(const uint8_t* data, size_t length, const std::optional<CookieRequestHeaderFieldProxy>&, Function<void(bool, bool)>&&) = 0;
+    virtual void platformClose() = 0;
+
+    URL m_url;
+    SocketStreamHandleClient& m_client;
+    SocketStreamState m_state;
+};
+
+} // namespace WebCore
+#endif

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/network/SocketStreamHandleClient.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/network/SocketStreamHandleClient.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2009 Apple Inc. All rights reserved.
+ * Copyright (C) 2009, 2011, 2012 Google Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(JAVA)
+namespace WebCore {
+
+class SocketStreamError;
+class SocketStreamHandle;
+
+class SocketStreamHandleClient {
+public:
+    virtual ~SocketStreamHandleClient() = default;
+
+    virtual void didOpenSocketStream(SocketStreamHandle&) = 0;
+    virtual void didCloseSocketStream(SocketStreamHandle&) = 0;
+    virtual void didReceiveSocketStreamData(SocketStreamHandle&, const uint8_t* data, size_t length) = 0;
+    virtual void didFailToReceiveSocketStreamData(SocketStreamHandle&) = 0;
+    virtual void didUpdateBufferedAmount(SocketStreamHandle&, size_t bufferedAmount) = 0;
+    virtual void didFailSocketStream(SocketStreamHandle&, const SocketStreamError&) = 0;
+};
+
+} // namespace WebCore
+#endif

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/network/SocketStreamHandleImpl.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/network/SocketStreamHandleImpl.cpp
@@ -1,0 +1,191 @@
+/*
+ * Copyright (C) 2017-2018 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SocketStreamHandleImpl.h"
+
+#if PLATFORM(JAVA)
+
+#include "CookieRequestHeaderFieldProxy.h"
+#include "NetworkStorageSession.h"
+#include "SocketStreamHandleClient.h"
+#include "StorageSessionProvider.h"
+#include <wtf/Function.h>
+
+namespace WebCore {
+
+void SocketStreamHandleImpl::platformSend(const uint8_t* data, size_t length, Function<void(bool)>&& completionHandler)
+{
+    if (!m_buffer.isEmpty()) {
+        if (m_buffer.size() + length > maxBufferSize) {
+            // FIXME: report error to indicate that buffer has no more space.
+            return completionHandler(false);
+        }
+        m_buffer.append(data, length);
+        m_client.didUpdateBufferedAmount(*this, bufferedAmount());
+        return completionHandler(true);
+    }
+    size_t bytesWritten = 0;
+    if (m_state == Open) {
+        if (auto result = platformSendInternal(data, length))
+            bytesWritten = result.value();
+        else
+            return completionHandler(false);
+    }
+    if (m_buffer.size() + length - bytesWritten > maxBufferSize) {
+        // FIXME: report error to indicate that buffer has no more space.
+        return completionHandler(false);
+    }
+    if (bytesWritten < length) {
+        m_buffer.append(data + bytesWritten, length - bytesWritten);
+        m_client.didUpdateBufferedAmount(static_cast<SocketStreamHandle&>(*this), bufferedAmount());
+    }
+    return completionHandler(true);
+}
+
+static size_t removeTerminationCharacters(const uint8_t* data, size_t dataLength)
+{
+#ifndef NDEBUG
+    ASSERT(dataLength > 2);
+    ASSERT(data[dataLength - 2] == '\r');
+    ASSERT(data[dataLength - 1] == '\n');
+#else
+    UNUSED_PARAM(data);
+#endif
+
+    // Remove the terminating '\r\n'
+    return dataLength - 2;
+}
+
+static std::optional<std::pair<Vector<uint8_t>, bool>> cookieDataForHandshake(const NetworkStorageSession* networkStorageSession, const CookieRequestHeaderFieldProxy& headerFieldProxy)
+{
+    if (!networkStorageSession)
+        return std::nullopt;
+
+    auto [cookieDataString, secureCookiesAccessed] = networkStorageSession->cookieRequestHeaderFieldValue(headerFieldProxy);
+    if (cookieDataString.isEmpty())
+        return std::pair<Vector<uint8_t>, bool> { { }, secureCookiesAccessed };
+
+    CString cookieData = cookieDataString.utf8();
+
+    Vector<uint8_t> data = { 'C', 'o', 'o', 'k', 'i', 'e', ':', ' ' };
+    data.append(cookieData.data(), cookieData.length());
+    data.appendVector(Vector<uint8_t>({ '\r', '\n', '\r', '\n' }));
+
+    return std::pair<Vector<uint8_t>, bool> { data, secureCookiesAccessed };
+}
+
+void SocketStreamHandleImpl::platformSendHandshake(const uint8_t* data, size_t length, const std::optional<CookieRequestHeaderFieldProxy>& headerFieldProxy, Function<void(bool, bool)>&& completionHandler)
+{
+    Vector<uint8_t> cookieData;
+    bool secureCookiesAccessed = false;
+
+    if (headerFieldProxy) {
+        auto cookieDataFromNetworkSession = cookieDataForHandshake(m_storageSessionProvider ? m_storageSessionProvider->storageSession() : nullptr, *headerFieldProxy);
+        if (!cookieDataFromNetworkSession) {
+            completionHandler(false, false);
+            return;
+        }
+
+        std::tie(cookieData, secureCookiesAccessed) = *cookieDataFromNetworkSession;
+        if (cookieData.size())
+            length = removeTerminationCharacters(data, length);
+    }
+
+    if (!m_buffer.isEmpty()) {
+        if (m_buffer.size() + length + cookieData.size() > maxBufferSize) {
+            // FIXME: report error to indicate that buffer has no more space.
+            return completionHandler(false, secureCookiesAccessed);
+        }
+        m_buffer.append(data, length);
+        m_buffer.append(cookieData.data(), cookieData.size());
+        m_client.didUpdateBufferedAmount(*this, bufferedAmount());
+        return completionHandler(true, secureCookiesAccessed);
+    }
+    size_t bytesWritten = 0;
+    if (m_state == Open) {
+        // Unfortunately, we need to send the data in one buffer or else the handshake fails.
+        Vector<uint8_t> sendData;
+        sendData.reserveInitialCapacity(length + cookieData.size());
+        sendData.append(data, length);
+        sendData.append(cookieData.data(), cookieData.size());
+
+        if (auto result = platformSendInternal(sendData.data(), sendData.size()))
+            bytesWritten = result.value();
+        else
+            return completionHandler(false, secureCookiesAccessed);
+    }
+    if (m_buffer.size() + length + cookieData.size() - bytesWritten > maxBufferSize) {
+        // FIXME: report error to indicate that buffer has no more space.
+        return completionHandler(false, secureCookiesAccessed);
+    }
+    if (bytesWritten < length + cookieData.size()) {
+        size_t cookieBytesWritten = 0;
+        if (bytesWritten < length)
+            m_buffer.append(data + bytesWritten, length - bytesWritten);
+        else
+            cookieBytesWritten = bytesWritten - length;
+        m_buffer.append(cookieData.data() + cookieBytesWritten, cookieData.size() - cookieBytesWritten);
+        m_client.didUpdateBufferedAmount(static_cast<SocketStreamHandle&>(*this), bufferedAmount());
+    }
+    return completionHandler(true, secureCookiesAccessed);
+}
+
+bool SocketStreamHandleImpl::sendPendingData()
+{
+    if (m_state != Open && m_state != Closing)
+        return false;
+    if (m_buffer.isEmpty()) {
+        if (m_state == Open)
+            return false;
+        if (m_state == Closing) {
+            disconnect();
+            return false;
+        }
+    }
+    bool pending;
+    do {
+        auto result = platformSendInternal(m_buffer.firstBlockData(), m_buffer.firstBlockSize());
+        if (!result)
+            return false;
+        size_t bytesWritten = result.value();
+        if (!bytesWritten)
+            return false;
+        pending = bytesWritten != m_buffer.firstBlockSize();
+        ASSERT(m_buffer.size() - bytesWritten <= maxBufferSize);
+        m_buffer.consume(bytesWritten);
+    } while (!pending && !m_buffer.isEmpty());
+    m_client.didUpdateBufferedAmount(static_cast<SocketStreamHandle&>(*this), bufferedAmount());
+    return true;
+}
+
+size_t SocketStreamHandleImpl::bufferedAmount()
+{
+    return m_buffer.size();
+}
+
+} // namespace WebCore
+
+#endif // #if PLATFORM(JAVA)

--- a/tests/manual/web/WebSocketTestApp.java
+++ b/tests/manual/web/WebSocketTestApp.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.geometry.Insets;
+import java.net.URL;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.VBox;
+import javafx.scene.web.WebEngine;
+import javafx.scene.web.WebView;
+import javafx.stage.Stage;
+
+public class WebSocketTestApp extends Application {
+
+    @Override
+    public void start(Stage primaryStage) throws Exception {
+
+        VBox instructions =  new VBox(
+                new Label(" This test is for manual websocket callback test , please follow below steps"),
+                new Label(" "),
+                new Label(" STEPS:"),
+                new Label("  1. Click on RunTest button"),
+                new Label(" "),
+                new Label("  2. Expected behaviour: Data received from server message should appear on webview"));
+
+        Button loadButton = new Button("RunTest");
+
+        Button passButton = new Button("Pass");
+        passButton.setOnAction(e -> {
+            Platform.exit();
+        });
+
+        Button failButton = new Button("Fail");
+        failButton.setOnAction(e -> {
+            Platform.exit();
+            throw new AssertionError("!Unable to receive message data from server, something is wrong");
+        });
+
+        WebView webView = new WebView();
+        WebEngine webEngine = webView.getEngine();
+
+        loadButton.setOnAction(e -> {
+            URL url = this.getClass().getResource("websocket.html");
+            System.out.println(url);
+            webView.getEngine().load(url.toString());
+        });
+
+        HBox buttons = new HBox(20, passButton, failButton);
+        HBox run_test = new HBox(20, loadButton);
+        buttons.setPadding(new Insets(10));
+        VBox rootNode = new VBox(20, new HBox(instructions), webView, buttons);
+        instructions.getChildren().add(run_test);
+        rootNode.setPadding(new Insets(10));
+        Scene scene = new Scene(rootNode, 1000, 600);
+        primaryStage.setScene(scene);
+        primaryStage.show();
+    }
+
+    public static void main(String[] args) {
+        launch(args);
+    }
+}

--- a/tests/manual/web/websocket.html
+++ b/tests/manual/web/websocket.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+    <body>
+        <p id="message"> </p>
+        <script>
+            let socket = new WebSocket("wss://echo.websocket.org/");
+            let messageElement = document.getElementById("message");
+
+            socket.onopen = function(e) {
+                messageElement.textContent = "[open] Connection established";
+                socket.send("Test WebSocket");
+                alert("[open] Connection established");
+            };
+
+            socket.onmessage = function(event) {
+                messageElement.textContent = '[message] Data received from server!';
+                alert('[message] Data received from server!');
+            };
+
+            socket.onerror = function(event) {
+                messageElement.textContent = "ERROR!";
+                alert("ERROR!");
+            };
+        </script>
+    </body>
+</html>
+


### PR DESCRIPTION
Hi all,

Please review a clean backport of [6a586b66](https://github.com/openjdk/jfx/commit/6a586b662592be3eb81670f0c5ce48061c2fc07c) from the [openjdk/jfx](https://git.openjdk.org/jfx) repository.

The commit being backported was authored by @theaoqi on 27 Jun 2024 and was reviewed by @kevinrushforth and @HimaBinduMeda. This is part of the prerequisites for backporting WebKit 619.1 to OpenJFX 21.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8331765](https://bugs.openjdk.org/browse/JDK-8331765) needs maintainer approval

### Issue
 * [JDK-8331765](https://bugs.openjdk.org/browse/JDK-8331765): Websocket callbacks are not executed after WebKit 617.1 update (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx21u.git pull/70/head:pull/70` \
`$ git checkout pull/70`

Update a local copy of the PR: \
`$ git checkout pull/70` \
`$ git pull https://git.openjdk.org/jfx21u.git pull/70/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 70`

View PR using the GUI difftool: \
`$ git pr show -t 70`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx21u/pull/70.diff">https://git.openjdk.org/jfx21u/pull/70.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx21u/pull/70#issuecomment-2340632543)