### PR TITLE
8331616: ChangeListener is not triggered when the InvalidationListener is removed

### DIFF
--- a/modules/javafx.base/src/main/java/com/sun/javafx/binding/ExpressionHelper.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/binding/ExpressionHelper.java
@@ -355,6 +355,22 @@ public abstract class ExpressionHelper<T> extends ExpressionHelperBase {
 
             try {
                 locked = true;
+
+                final T oldValue = currentValue;
+
+                if (curChangeSize > 0) {
+
+                    /*
+                     * Because invalidation listeners may get removed during notification, this may
+                     * change the Helper type from Generic to SingleChange. When this transition
+                     * occurs, it is essential the correct current value is passed to the new
+                     * SingleChange instance. This is why the currentValue is already obtained
+                     * before notifying the invalidation listeners.
+                     */
+
+                    currentValue = observable.getValue();
+                }
+
                 for (int i = 0; i < curInvalidationSize; i++) {
                     try {
                         curInvalidationList[i].invalidated(observable);
@@ -363,8 +379,6 @@ public abstract class ExpressionHelper<T> extends ExpressionHelperBase {
                     }
                 }
                 if (curChangeSize > 0) {
-                    final T oldValue = currentValue;
-                    currentValue = observable.getValue();
                     final boolean changed = (currentValue == null)? (oldValue != null) : !currentValue.equals(oldValue);
                     if (changed) {
                         for (int i = 0; i < curChangeSize; i++) {

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/ExpressionHelperTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/ExpressionHelperTest.java
@@ -682,7 +682,7 @@ public class ExpressionHelperTest {
         StringProperty p = new SimpleStringProperty("a") {
             @Override
             protected void invalidated() {
-                removeListener(invalidationListener);
+                removeListener(invalidationListener);  // this removal occurs before notification
             }
         };
 
@@ -693,6 +693,56 @@ public class ExpressionHelperTest {
 
         assertFalse(invalidated.get());  // false because the invalidation listener was removed before called
         assertEquals("b", currentValue.get());
+
+        p.set("a");  // if current value wasn't copied correctly (it is still "a") then this wouldn't trigger a change
+
+        assertEquals("a", currentValue.get());
+    }
+
+    @Test
+    public void shouldNotForgetCurrentValueWhenMovingFromChangeListenerAndInvalidationListenerToSingleChangeListener() {
+        AtomicReference<String> currentValue = new AtomicReference<>();
+        StringProperty p = new SimpleStringProperty("a");
+        InvalidationListener invalidationListener = new InvalidationListener() {
+            @Override
+            public void invalidated(Observable obs) {
+                p.removeListener(this);  // this removal occurs during notification
+            }
+        };
+
+        p.addListener(invalidationListener);
+        p.addListener((obs, old, current) -> currentValue.set(current));
+
+        p.set("b");
+
+        assertEquals("b", currentValue.get());
+
+        p.set("a");  // if current value wasn't copied correctly (it is still "a") then this wouldn't trigger a change
+
+        assertEquals("a", currentValue.get());
+    }
+
+    @Test
+    public void shouldNotForgetCurrentValueWhenMovingFromTwoChangeListenersToSingleChangeListener() {
+        AtomicReference<String> currentValue = new AtomicReference<>();
+        StringProperty p = new SimpleStringProperty("a");
+        ChangeListener<String> changeListener = new ChangeListener<>() {
+            @Override
+            public void changed(ObservableValue<? extends String> observable, String oldValue, String newValue) {
+                p.removeListener(this);
+            }
+        };
+
+        p.addListener(changeListener);
+        p.addListener((obs, old, current) -> currentValue.set(current));
+
+        p.set("b");
+
+        assertEquals("b", currentValue.get());
+
+        p.set("a");  // if current value wasn't copied correctly (it is still "a") then this wouldn't trigger a change
+
+        assertEquals("a", currentValue.get());
     }
 
     @Test


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8331616](https://bugs.openjdk.org/browse/JDK-8331616) needs maintainer approval

### Issue
 * [JDK-8331616](https://bugs.openjdk.org/browse/JDK-8331616): ChangeListener is not triggered when the InvalidationListener is removed (**Bug** - P3 - Approved)


### Reviewers
 * [John Hendrikx](https://openjdk.org/census#jhendrikx) (@hjohn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx21u.git pull/74/head:pull/74` \
`$ git checkout pull/74`

Update a local copy of the PR: \
`$ git checkout pull/74` \
`$ git pull https://git.openjdk.org/jfx21u.git pull/74/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 74`

View PR using the GUI difftool: \
`$ git pr show -t 74`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx21u/pull/74.diff">https://git.openjdk.org/jfx21u/pull/74.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx21u/pull/74#issuecomment-2444274433)
</details>
