### PR TITLE
8351038: ConcurrentModificationException in EventType constructor

### DIFF
--- a/modules/javafx.base/src/main/java/javafx/event/EventType.java
+++ b/modules/javafx.base/src/main/java/javafx/event/EventType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,8 +64,7 @@ public final class EventType<T extends Event> implements Serializable{
      * indirect sub types of it. It is also the only event type which
      * has its super event type set to {@code null}.
      */
-    public static final EventType<Event> ROOT =
-            new EventType<>("EVENT", null);
+    public static final EventType<Event> ROOT = new EventType<>("EVENT", true);
 
     private WeakHashMap<EventType<? extends T>, Void> subTypes;
 
@@ -129,23 +128,11 @@ public final class EventType<T extends Event> implements Serializable{
     }
 
     /**
-     * Internal constructor that skips various checks
+     * Internal constructor for the ROOT instance that skips various checks
      */
-    EventType(final String name,
-                      final EventType<? super T> superType) {
-        this.superType = superType;
+    private EventType(String name, boolean ignored) {
+        this.superType = null;
         this.name = name;
-        if (superType != null) {
-            if (superType.subTypes != null) {
-                for (Iterator i = superType.subTypes.keySet().iterator(); i.hasNext();) {
-                    EventType t  = (EventType) i.next();
-                    if (name == null && t.name == null || (name != null && name.equals(t.name))) {
-                        i.remove();
-                    }
-                }
-            }
-            superType.register(this);
-        }
     }
 
     /**
@@ -176,7 +163,7 @@ public final class EventType<T extends Event> implements Serializable{
         return (name != null) ? name : super.toString();
     }
 
-    private void register(javafx.event.EventType<? extends T> subType) {
+    private synchronized void register(javafx.event.EventType<? extends T> subType) {
         if (subTypes == null) {
             subTypes = new WeakHashMap<>();
         }

--- a/modules/javafx.base/src/test/java/test/javafx/event/EventTypeConcurrencyTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/event/EventTypeConcurrencyTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package test.javafx.event;
+
+import static org.junit.jupiter.api.Assertions.fail;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import javafx.event.Event;
+import javafx.event.EventType;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Developers should be able to create EventTypes in background thread(s).
+ */
+public class EventTypeConcurrencyTest {
+    @Test
+    public void concurrentInitialization() {
+        int N = 1_000;
+        try (var executor = Executors.newCachedThreadPool()) {
+            try {
+                ArrayList<Callable<Object>> runs = new ArrayList<>(N);
+                for (int i = 0; i < N; i++) {
+                    String name = "TEST" + i;
+                    runs.add(() -> {
+                        return new EventType<>(Event.ANY, name);
+                    });
+                }
+
+                List<Future<Object>> futures = executor.invokeAll(runs);
+
+                for (Future<Object> future : futures) {
+                    future.get();
+                }
+            } catch (Throwable e) {
+                fail(e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hi all,

This pull request contains an almost-clean backport of commit 0e509616 from the openjdk/jfx repository. Only the (c) date had to be manually modified.

The commit being backported was authored by Andy Goryachev on 19 Mar 2025 and was reviewed by Ambarish Rapte and Michael Strauß.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8351038](https://bugs.openjdk.org/browse/JDK-8351038) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351038](https://bugs.openjdk.org/browse/JDK-8351038): ConcurrentModificationException in EventType constructor (**Bug** - P3 - Approved)


### Reviewers
 * [Jose Pereda](https://openjdk.org/census#jpereda) (@jperedadnr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx21u.git pull/100/head:pull/100` \
`$ git checkout pull/100`

Update a local copy of the PR: \
`$ git checkout pull/100` \
`$ git pull https://git.openjdk.org/jfx21u.git pull/100/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 100`

View PR using the GUI difftool: \
`$ git pr show -t 100`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx21u/pull/100.diff">https://git.openjdk.org/jfx21u/pull/100.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx21u/pull/100#issuecomment-2979389801)
</details>
