### PR TITLE
8381517: GlassViewDelegate::convertNSStringToJString can return uninitialized value

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassViewDelegate.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassViewDelegate.m
@@ -1133,10 +1133,14 @@ static jstring convertNSStringToJString(id aString, int length)
 {
     GET_MAIN_JENV;
 
-    jstring jStr;
+    jstring jStr = NULL;
     if ([aString isKindOfClass:[NSAttributedString class]]) {
+        if (length <= 0 || length > SIZE_MAX / sizeof(jchar)) {
+            return NULL;
+        }
+
         NSData *data = [[aString string] dataUsingEncoding:NSUTF16LittleEndianStringEncoding];
-        jchar *dataBytes = (jchar *)malloc(sizeof(jchar) * length);
+        jchar *dataBytes = (jchar *)malloc(sizeof(jchar) * (size_t)length);
         if (dataBytes != NULL) {
             [data getBytes:dataBytes length:length * 2];
             jStr = (*env)->NewString(env, dataBytes, length);


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [c835a249](https://github.com/openjdk/jfx/commit/c835a24920e4caaa2228225a4f1ffd992109e10b) from the [openjdk/jfx](https://git.openjdk.org/jfx) repository.

The commit being backported was authored by Kevin Rushforth on 2 Apr 2026 and was reviewed by Andy Goryachev and Jayathirth D V.

Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8381517](https://bugs.openjdk.org/browse/JDK-8381517) needs maintainer approval

### Issue
 * [JDK-8381517](https://bugs.openjdk.org/browse/JDK-8381517): GlassViewDelegate::convertNSStringToJString can return uninitialized value (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx21u.git pull/132/head:pull/132` \
`$ git checkout pull/132`

Update a local copy of the PR: \
`$ git checkout pull/132` \
`$ git pull https://git.openjdk.org/jfx21u.git pull/132/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 132`

View PR using the GUI difftool: \
`$ git pr show -t 132`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx21u/pull/132.diff">https://git.openjdk.org/jfx21u/pull/132.diff</a>

</details>
