### PR TITLE
8367374: JavaFX debug builds fail on Windows

### DIFF
--- a/modules/javafx.web/src/main/native/Source/ThirdParty/icu/CMakeLists.txt
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/icu/CMakeLists.txt
@@ -1,12 +1,13 @@
 # http://userguide.icu-project.org/howtouseicu#TOC-C-With-Your-Own-Build-System
 if(WIN32)
-set(CMAKE_CXX_FLAGS "" CACHE STRING "Clear CXX flags for this sub-project" FORCE)
-set(CMAKE_CXX_COMPILER "${MSVC_BIN_DIR}/cl.exe")
-#set(CMAKE_C_COMPILER "${MSVC_BIN_DIR}/cl.exe")
-set(CMAKE_LINKER "${MSVC_BIN_DIR}/link.exe")
-set(CMAKE_PROGRAM "${MSVC_BIN_DIR}/nmake.exe")
-set(CMAKE_AR "${MSVC_BIN_DIR}/lib.exe")
-add_compile_options(/FS)
+  set(CMAKE_CXX_FLAGS "" CACHE STRING "Clear CXX flags for this sub-project" FORCE)
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
+  set(CMAKE_C_COMPILER   "${MSVC_BIN_DIR}/cl.exe" CACHE FILEPATH "" FORCE)
+  set(CMAKE_CXX_COMPILER "${MSVC_BIN_DIR}/cl.exe" CACHE FILEPATH "" FORCE)
+  set(CMAKE_LINKER       "${MSVC_BIN_DIR}/link.exe" CACHE FILEPATH "" FORCE)
+  set(CMAKE_AR           "${MSVC_BIN_DIR}/lib.exe" CACHE FILEPATH "" FORCE)
+
+  add_compile_options(/FS)
 endif()
 
 set(ICU_PUBLIC_DEFINES
@@ -612,6 +613,7 @@ add_custom_command(
 if (MSVC)
     # On Windows, data_as_asm could generates .obj file directly.
     set(ICU_DATA_SYMBOL_FILE "${CMAKE_BINARY_DIR}/icu/data/${ICU_DATA_FILE_NAME}_dat.obj")
+    message(STATUS "ICU_DATA_SYMBOL_FILE = ${ICU_DATA_SYMBOL_FILE}")
     set_source_files_properties(${ICU_DATA_SYMBOL_FILE} PROPERTIES EXTERNAL_OBJECT TRUE GENERATED TRUE)
 else ()
     set(ICU_DATA_SYMBOL_FILE "${CMAKE_BINARY_DIR}/icu/data/${ICU_DATA_FILE_NAME}_dat.S")


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit 49bece0a from the openjdk/jfx repository.

The commit being backported was authored by Jay Bhaskar on 17 Sep 2025 and was reviewed by Kevin Rushforth and Hima Bindu Meda.

Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] [JDK-8367374](https://bugs.openjdk.org/browse/JDK-8367374) needs maintainer approval
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8367374](https://bugs.openjdk.org/browse/JDK-8367374): JavaFX debug builds fail on Windows (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx21u.git pull/139/head:pull/139` \
`$ git checkout pull/139`

Update a local copy of the PR: \
`$ git checkout pull/139` \
`$ git pull https://git.openjdk.org/jfx21u.git pull/139/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 139`

View PR using the GUI difftool: \
`$ git pr show -t 139`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx21u/pull/139.diff">https://git.openjdk.org/jfx21u/pull/139.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx21u/pull/139#issuecomment-5278369701)
</details>
